### PR TITLE
feat(#186): Live Score - Suivi en direct des matchs

### DIFF
--- a/ajax/live_score.php
+++ b/ajax/live_score.php
@@ -1,0 +1,152 @@
+<?php
+
+header('Content-Type: application/json; charset=utf-8');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type');
+
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    http_response_code(200);
+    exit();
+}
+
+require_once __DIR__ . '/../classes/LiveScore.php';
+require_once __DIR__ . '/../classes/MatchMgr.php';
+require_once __DIR__ . '/../classes/UserManager.php';
+
+/**
+ * Check if user can modify live score for a match
+ */
+function canModifyLiveScore($id_match): bool {
+    @session_start();
+    
+    // Admin can always modify
+    if (UserManager::isAdmin()) {
+        return true;
+    }
+    
+    // Must be logged in with a team
+    if (!isset($_SESSION['id_equipe'])) {
+        return false;
+    }
+    
+    // Check if user's team is playing this match
+    try {
+        $manager = new MatchMgr();
+        $match = $manager->get_match_by_code_match($id_match);
+        $userTeamId = $_SESSION['id_equipe'];
+        return ($userTeamId == $match['id_equipe_dom'] || $userTeamId == $match['id_equipe_ext']);
+    } catch (Exception $e) {
+        return false;
+    }
+}
+
+try {
+    $liveScore = new LiveScore();
+    $method = $_SERVER['REQUEST_METHOD'];
+
+    if ($method === 'GET') {
+        $id_match = filter_input(INPUT_GET, 'id_match', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+        
+        if ($id_match) {
+            $result = $liveScore->getLiveScore($id_match);
+            echo json_encode([
+                'success' => true,
+                'data' => $result
+            ]);
+        } else {
+            $results = $liveScore->getActiveLiveScores();
+            echo json_encode([
+                'success' => true,
+                'data' => $results
+            ]);
+        }
+    } elseif ($method === 'POST') {
+        $input = json_decode(file_get_contents('php://input'), true);
+        
+        if (empty($input['action']) || empty($input['id_match'])) {
+            throw new Exception("Missing required parameters: action and id_match");
+        }
+
+        $id_match = $input['id_match'];
+        $action = $input['action'];
+
+        // Authorization check for all POST actions
+        if (!canModifyLiveScore($id_match)) {
+            http_response_code(403);
+            throw new Exception("Non autorisé: vous devez être administrateur ou responsable d'une des équipes du match");
+        }
+
+        switch ($action) {
+            case 'start':
+                $id = $liveScore->startLiveScore($id_match);
+                echo json_encode([
+                    'success' => true,
+                    'message' => 'Live score started',
+                    'id' => $id
+                ]);
+                break;
+
+            case 'increment':
+                if (empty($input['team']) || !in_array($input['team'], ['dom', 'ext'])) {
+                    throw new Exception("Invalid team parameter");
+                }
+                $liveScore->incrementScore($id_match, $input['team']);
+                $result = $liveScore->getLiveScore($id_match);
+                echo json_encode([
+                    'success' => true,
+                    'data' => $result
+                ]);
+                break;
+
+            case 'decrement':
+                if (empty($input['team']) || !in_array($input['team'], ['dom', 'ext'])) {
+                    throw new Exception("Invalid team parameter");
+                }
+                $liveScore->decrementScore($id_match, $input['team']);
+                $result = $liveScore->getLiveScore($id_match);
+                echo json_encode([
+                    'success' => true,
+                    'data' => $result
+                ]);
+                break;
+
+            case 'next_set':
+                $setWinner = $input['set_winner'] ?? null;
+                $liveScore->nextSet($id_match, $setWinner);
+                $result = $liveScore->getLiveScore($id_match);
+                echo json_encode([
+                    'success' => true,
+                    'data' => $result
+                ]);
+                break;
+
+            case 'end':
+                $liveScore->endLiveScore($id_match);
+                echo json_encode([
+                    'success' => true,
+                    'message' => 'Live score ended'
+                ]);
+                break;
+
+            case 'save_to_match':
+                $liveScore->saveToMatch($id_match);
+                echo json_encode([
+                    'success' => true,
+                    'message' => 'Scores enregistrés dans le match'
+                ]);
+                break;
+
+            default:
+                throw new Exception("Unknown action: $action");
+        }
+    } else {
+        throw new Exception("Method not allowed");
+    }
+} catch (Exception $e) {
+    http_response_code(400);
+    echo json_encode([
+        'success' => false,
+        'error' => $e->getMessage()
+    ]);
+}

--- a/classes/LiveScore.php
+++ b/classes/LiveScore.php
@@ -1,0 +1,218 @@
+<?php
+
+require_once __DIR__ . '/Generic.php';
+
+class LiveScore extends Generic
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->table_name = 'live_scores';
+        $this->id_name = 'id';
+    }
+
+    /**
+     * Get live score for a match
+     * @param int $id_match
+     * @return array|null
+     * @throws Exception
+     */
+    public function getLiveScore(string|int $id_match): ?array
+    {
+        $sql = "SELECT * FROM live_scores WHERE id_match = ? AND is_active = 1";
+        $bindings = array(
+            array('type' => 's', 'value' => $id_match)
+        );
+        $results = $this->sql_manager->execute($sql, $bindings);
+        return empty($results) ? null : $results[0];
+    }
+
+    /**
+     * Start a new live score session for a match
+     * @param int $id_match
+     * @return int|string Insert ID
+     * @throws Exception
+     */
+    public function startLiveScore(string|int $id_match): int|string
+    {
+        $existing = $this->getLiveScore($id_match);
+        if ($existing) {
+            return $existing['id'];
+        }
+
+        $sql = "INSERT INTO live_scores (id_match, set_en_cours, score_dom, score_ext, sets_dom, sets_ext, is_active) 
+                VALUES (?, 1, 0, 0, 0, 0, 1)";
+        $bindings = array(
+            array('type' => 's', 'value' => $id_match)
+        );
+        return $this->sql_manager->execute($sql, $bindings);
+    }
+
+    /**
+     * Increment score for a team
+     * @param int $id_match
+     * @param string $team 'dom' or 'ext'
+     * @throws Exception
+     */
+    public function incrementScore(string|int $id_match, string $team): void
+    {
+        if (!in_array($team, ['dom', 'ext'])) {
+            throw new Exception("Invalid team: must be 'dom' or 'ext'");
+        }
+
+        $column = "score_$team";
+        $sql = "UPDATE live_scores SET $column = $column + 1 WHERE id_match = ? AND is_active = 1";
+        $bindings = array(
+            array('type' => 's', 'value' => $id_match)
+        );
+        $this->sql_manager->execute($sql, $bindings);
+    }
+
+    /**
+     * Decrement score for a team (cannot go below 0)
+     * @param int $id_match
+     * @param string $team 'dom' or 'ext'
+     * @throws Exception
+     */
+    public function decrementScore(string|int $id_match, string $team): void
+    {
+        if (!in_array($team, ['dom', 'ext'])) {
+            throw new Exception("Invalid team: must be 'dom' or 'ext'");
+        }
+
+        $column = "score_$team";
+        $sql = "UPDATE live_scores SET $column = GREATEST(0, $column - 1) WHERE id_match = ? AND is_active = 1";
+        $bindings = array(
+            array('type' => 's', 'value' => $id_match)
+        );
+        $this->sql_manager->execute($sql, $bindings);
+    }
+
+    /**
+     * Move to next set, save current set scores, reset point scores, increment set for winner
+     * @param string|int $id_match
+     * @param string|null $setWinner 'dom' or 'ext' - who won the set
+     * @throws Exception
+     */
+    public function nextSet(string|int $id_match, ?string $setWinner = null): void
+    {
+        $current = $this->getLiveScore($id_match);
+        if (!$current) {
+            throw new Exception("No active live score for this match");
+        }
+
+        $setNum = $current['set_en_cours'];
+        if ($setNum > 5) {
+            throw new Exception("Cannot exceed 5 sets");
+        }
+
+        // Save current scores to set columns
+        $setDomCol = "set_{$setNum}_dom";
+        $setExtCol = "set_{$setNum}_ext";
+        
+        $updates = "$setDomCol = ?, $setExtCol = ?, set_en_cours = set_en_cours + 1, score_dom = 0, score_ext = 0";
+        
+        if ($setWinner === 'dom') {
+            $updates .= ", sets_dom = sets_dom + 1";
+        } elseif ($setWinner === 'ext') {
+            $updates .= ", sets_ext = sets_ext + 1";
+        }
+
+        $sql = "UPDATE live_scores SET $updates WHERE id_match = ? AND is_active = 1";
+        $bindings = array(
+            array('type' => 'i', 'value' => $current['score_dom']),
+            array('type' => 'i', 'value' => $current['score_ext']),
+            array('type' => 's', 'value' => $id_match)
+        );
+        $this->sql_manager->execute($sql, $bindings);
+    }
+
+    /**
+     * Delete live score for a match
+     * @param int $id_match
+     * @throws Exception
+     */
+    public function deleteLiveScore(string|int $id_match): void
+    {
+        $sql = "DELETE FROM live_scores WHERE id_match = ?";
+        $bindings = array(
+            array('type' => 's', 'value' => $id_match)
+        );
+        $this->sql_manager->execute($sql, $bindings);
+    }
+
+    /**
+     * End live score session (mark as inactive)
+     * @param string|int $id_match
+     * @throws Exception
+     */
+    public function endLiveScore(string|int $id_match): void
+    {
+        $sql = "UPDATE live_scores SET is_active = 0 WHERE id_match = ?";
+        $bindings = array(
+            array('type' => 's', 'value' => $id_match)
+        );
+        $this->sql_manager->execute($sql, $bindings);
+    }
+
+    /**
+     * Save live score data to the matches table
+     * @param string|int $id_match code_match
+     * @throws Exception
+     */
+    public function saveToMatch(string|int $id_match): void
+    {
+        $liveScore = $this->getLiveScore($id_match);
+        if (!$liveScore) {
+            throw new Exception("No live score found for this match");
+        }
+
+        $sql = "UPDATE matches SET 
+                    set_1_dom = ?, set_1_ext = ?,
+                    set_2_dom = ?, set_2_ext = ?,
+                    set_3_dom = ?, set_3_ext = ?,
+                    set_4_dom = ?, set_4_ext = ?,
+                    set_5_dom = ?, set_5_ext = ?
+                WHERE code_match = ?";
+        
+        $bindings = array(
+            array('type' => 'i', 'value' => $liveScore['set_1_dom']),
+            array('type' => 'i', 'value' => $liveScore['set_1_ext']),
+            array('type' => 'i', 'value' => $liveScore['set_2_dom']),
+            array('type' => 'i', 'value' => $liveScore['set_2_ext']),
+            array('type' => 'i', 'value' => $liveScore['set_3_dom']),
+            array('type' => 'i', 'value' => $liveScore['set_3_ext']),
+            array('type' => 'i', 'value' => $liveScore['set_4_dom']),
+            array('type' => 'i', 'value' => $liveScore['set_4_ext']),
+            array('type' => 'i', 'value' => $liveScore['set_5_dom']),
+            array('type' => 'i', 'value' => $liveScore['set_5_ext']),
+            array('type' => 's', 'value' => $id_match)
+        );
+        
+        $this->sql_manager->execute($sql, $bindings);
+        
+        // End the live score session after saving
+        $this->endLiveScore($id_match);
+    }
+
+    /**
+     * Get all active live scores with match details
+     * @return array
+     * @throws Exception
+     */
+    public function getActiveLiveScores(): array
+    {
+        $sql = "SELECT 
+                    ls.*,
+                    m.code_match,
+                    m.equipe_dom,
+                    m.equipe_ext,
+                    m.code_competition,
+                    m.division
+                FROM live_scores ls
+                JOIN matchs_view m ON m.id_match = ls.id_match
+                WHERE ls.is_active = 1
+                ORDER BY ls.updated_at DESC";
+        return $this->sql_manager->execute($sql);
+    }
+}

--- a/live.php
+++ b/live.php
@@ -1,0 +1,413 @@
+<?php
+require_once __DIR__ . '/classes/MatchMgr.php';
+require_once __DIR__ . '/classes/LiveScore.php';
+require_once __DIR__ . '/classes/UserManager.php';
+
+$id_match = filter_input(INPUT_GET, 'id_match');
+$mode = filter_input(INPUT_GET, 'mode') ?? 'view'; // 'view' or 'scorer'
+
+$match = null;
+$liveScoreData = null;
+$error = null;
+$isScorer = ($mode === 'scorer');
+
+@session_start();
+$isLoggedIn = isset($_SESSION['login']);
+$isAdmin = UserManager::isAdmin();
+$canScore = false;
+
+if ($id_match) {
+    try {
+        $manager = new MatchMgr();
+        $match = $manager->get_match_by_code_match($id_match);
+        
+        $liveScore = new LiveScore();
+        $liveScoreData = $liveScore->getLiveScore($id_match);
+        
+        // Check scorer permissions: admin OR team leader of one of the teams
+        if ($isAdmin) {
+            $canScore = true;
+        } elseif ($isLoggedIn && isset($_SESSION['id_equipe'])) {
+            $userTeamId = $_SESSION['id_equipe'];
+            $canScore = ($userTeamId == $match['id_equipe_dom'] || $userTeamId == $match['id_equipe_ext']);
+        }
+    } catch (Exception $e) {
+        $error = $e->getMessage();
+    }
+}
+?>
+<!DOCTYPE html>
+<HTML data-theme="cupcake" lang="fr">
+<HEAD>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <TITLE>Live Score<?php echo $match ? ' - ' . htmlspecialchars($match['code_match']) : ''; ?></TITLE>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://cdn.jsdelivr.net/npm/daisyui@4.12.2/dist/full.min.css" rel="stylesheet" type="text/css"/>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.1/css/all.min.css"
+          integrity="sha512-MV7K8+y+gLIBoVD59lQIYicR65iaqukzvf/nwasF0nqhPay5w/9lJmVM2hMDcnK1OnMGCdVK+iQrJ7lzPJQd1w=="
+          crossorigin="anonymous" referrerpolicy="no-referrer"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
+</HEAD>
+<BODY>
+<div id="app" class="min-h-screen bg-base-200">
+    <!-- Header -->
+    <div class="navbar bg-primary text-primary-content">
+        <div class="flex-1">
+            <a href="/pages/home.html" class="btn btn-ghost text-xl">
+                <i class="fas fa-volleyball"></i> UFOLEP 13
+            </a>
+        </div>
+        <div class="flex-none">
+            <span class="badge badge-secondary" v-if="isLive">
+                <i class="fas fa-circle text-red-500 animate-pulse mr-1"></i> LIVE
+            </span>
+        </div>
+    </div>
+
+    <!-- Match Info -->
+    <div class="container mx-auto p-4 max-w-2xl">
+        <?php if ($error): ?>
+        <div class="alert alert-error mb-4">
+            <i class="fas fa-exclamation-triangle"></i>
+            <span>Erreur: <?php echo htmlspecialchars($error); ?></span>
+        </div>
+        <?php endif; ?>
+        
+        <?php if ($match): ?>
+        <!-- Competition Badge -->
+        <div class="text-center mb-4">
+            <span class="badge badge-info badge-lg"><?php echo htmlspecialchars($match['libelle_competition']); ?></span>
+            <span class="badge badge-outline ml-2">Division <?php echo htmlspecialchars($match['division']); ?></span>
+        </div>
+
+        <!-- Score Board -->
+        <div class="card bg-base-100 shadow-xl mb-4">
+            <div class="card-body p-4">
+                <!-- Teams and Score -->
+                <div class="grid grid-cols-3 gap-2 items-center text-center">
+                    <!-- Home Team -->
+                    <div>
+                        <p class="font-bold text-lg truncate"><?php echo htmlspecialchars($match['equipe_dom']); ?></p>
+                        <p class="text-xs text-gray-500">Domicile</p>
+                    </div>
+                    
+                    <!-- Score -->
+                    <div>
+                        <div class="text-5xl font-bold">
+                            <span class="text-primary">{{ score.score_dom }}</span>
+                            <span class="text-gray-400">-</span>
+                            <span class="text-secondary">{{ score.score_ext }}</span>
+                        </div>
+                        <p class="text-sm mt-1">Set {{ score.set_en_cours }}</p>
+                        <p class="text-lg font-bold">({{ score.sets_dom }} - {{ score.sets_ext }})</p>
+                        
+                        <!-- Set Details -->
+                        <div class="text-xs text-gray-500 mt-2 flex gap-2 justify-center flex-wrap">
+                            <span v-if="score.set_1_dom || score.set_1_ext" class="badge badge-ghost">S1: {{ score.set_1_dom }}-{{ score.set_1_ext }}</span>
+                            <span v-if="score.set_2_dom || score.set_2_ext" class="badge badge-ghost">S2: {{ score.set_2_dom }}-{{ score.set_2_ext }}</span>
+                            <span v-if="score.set_3_dom || score.set_3_ext" class="badge badge-ghost">S3: {{ score.set_3_dom }}-{{ score.set_3_ext }}</span>
+                            <span v-if="score.set_4_dom || score.set_4_ext" class="badge badge-ghost">S4: {{ score.set_4_dom }}-{{ score.set_4_ext }}</span>
+                            <span v-if="score.set_5_dom || score.set_5_ext" class="badge badge-ghost">S5: {{ score.set_5_dom }}-{{ score.set_5_ext }}</span>
+                        </div>
+                    </div>
+                    
+                    <!-- Away Team -->
+                    <div>
+                        <p class="font-bold text-lg truncate"><?php echo htmlspecialchars($match['equipe_ext']); ?></p>
+                        <p class="text-xs text-gray-500">Extérieur</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Scorer Controls (only for authorized users in scorer mode) -->
+        <?php if ($canScore && $isScorer): ?>
+        <div class="card bg-base-100 shadow-xl mb-4" v-if="isLive">
+            <div class="card-body p-4">
+                <h3 class="text-center font-bold mb-4">Contrôles Scoreur</h3>
+                
+                <!-- Score Buttons -->
+                <div class="grid grid-cols-2 gap-4 mb-4">
+                    <!-- Dom buttons -->
+                    <div class="flex flex-col gap-2">
+                        <button @click="incrementScore('dom')" 
+                                class="btn btn-primary btn-lg h-24 text-3xl">
+                            +1
+                        </button>
+                        <button @click="decrementScore('dom')" 
+                                class="btn btn-outline btn-sm">
+                            -1
+                        </button>
+                    </div>
+                    
+                    <!-- Ext buttons -->
+                    <div class="flex flex-col gap-2">
+                        <button @click="incrementScore('ext')" 
+                                class="btn btn-secondary btn-lg h-24 text-3xl">
+                            +1
+                        </button>
+                        <button @click="decrementScore('ext')" 
+                                class="btn btn-outline btn-sm">
+                            -1
+                        </button>
+                    </div>
+                </div>
+                
+                <!-- Set Controls -->
+                <div class="divider">Gestion des Sets</div>
+                <div class="grid grid-cols-2 gap-2">
+                    <button @click="nextSet('dom')" class="btn btn-outline btn-primary">
+                        <i class="fas fa-trophy mr-1"></i> Set gagné DOM
+                    </button>
+                    <button @click="nextSet('ext')" class="btn btn-outline btn-secondary">
+                        <i class="fas fa-trophy mr-1"></i> Set gagné EXT
+                    </button>
+                </div>
+                
+                <!-- End Match -->
+                <div class="mt-4 flex flex-col gap-2">
+                    <button @click="saveToMatch()" class="btn btn-success btn-block" v-if="score && (score.sets_dom >= 3 || score.sets_ext >= 3)">
+                        <i class="fas fa-save mr-1"></i> Renseigner les scores du match
+                    </button>
+                    <button @click="endLiveScore()" class="btn btn-error btn-block">
+                        <i class="fas fa-stop mr-1"></i> Terminer le Live
+                    </button>
+                </div>
+            </div>
+        </div>
+        
+        <!-- Start Live Button -->
+        <div class="text-center mb-4" v-if="!isLive">
+            <button @click="startLiveScore()" class="btn btn-success btn-lg">
+                <i class="fas fa-play mr-2"></i> Démarrer le Live Score
+            </button>
+        </div>
+        <?php endif; ?>
+
+        <!-- Status Messages -->
+        <div class="alert alert-info mb-4" v-if="!isLive && !isScorer">
+            <i class="fas fa-info-circle"></i>
+            <span>Le live score n'est pas encore démarré pour ce match.</span>
+        </div>
+
+        <!-- Auto-refresh indicator -->
+        <div class="text-center text-sm text-gray-500" v-if="isLive && !isScorer">
+            <i class="fas fa-sync-alt animate-spin mr-1"></i>
+            Mise à jour automatique toutes les 5 secondes
+        </div>
+
+        <!-- Match Details -->
+        <div class="card bg-base-100 shadow-xl">
+            <div class="card-body p-4">
+                <div class="grid grid-cols-2 gap-2 text-sm">
+                    <div><i class="fas fa-calendar mr-1"></i> <?php echo htmlspecialchars($match['date_reception'] ?? 'Non définie'); ?></div>
+                    <div><i class="fas fa-clock mr-1"></i> <?php echo htmlspecialchars($match['heure_reception'] ?? ''); ?></div>
+                    <div class="col-span-2"><i class="fas fa-map-marker-alt mr-1"></i> <?php echo htmlspecialchars($match['gymnasium'] ?? 'Non défini'); ?></div>
+                </div>
+            </div>
+        </div>
+
+        <?php else: ?>
+        <!-- No match selected - show active live scores -->
+        <div class="text-center mb-6">
+            <h2 class="text-2xl font-bold mb-2">Matchs en direct</h2>
+            <p class="text-gray-500">Sélectionnez un match pour suivre le score</p>
+        </div>
+        
+        <div v-if="activeLiveScores.length === 0" class="alert alert-info">
+            <i class="fas fa-info-circle"></i>
+            <span>Aucun match en direct actuellement.</span>
+        </div>
+        
+        <div v-for="live in activeLiveScores" :key="live.id_match" class="card bg-base-100 shadow-xl mb-4">
+            <div class="card-body p-4">
+                <div class="flex justify-between items-center">
+                    <div>
+                        <p class="font-bold">{{ live.equipe_dom }} vs {{ live.equipe_ext }}</p>
+                        <p class="text-sm text-gray-500">{{ live.code_competition }} - Div {{ live.division }}</p>
+                    </div>
+                    <div class="text-center">
+                        <p class="text-2xl font-bold">{{ live.score_dom }} - {{ live.score_ext }}</p>
+                        <p class="text-xs">Set {{ live.set_en_cours }}</p>
+                    </div>
+                    <a :href="'/live.php?id_match=' + live.id_match" class="btn btn-primary btn-sm">
+                        <i class="fas fa-eye"></i> Voir
+                    </a>
+                </div>
+            </div>
+        </div>
+        <?php endif; ?>
+    </div>
+</div>
+
+<script>
+new Vue({
+    el: '#app',
+    data: {
+        idMatch: <?php echo json_encode($id_match); ?>,
+        isScorer: <?php echo json_encode($isScorer); ?>,
+        score: {
+            set_en_cours: <?php echo $liveScoreData['set_en_cours'] ?? 1; ?>,
+            score_dom: <?php echo $liveScoreData['score_dom'] ?? 0; ?>,
+            score_ext: <?php echo $liveScoreData['score_ext'] ?? 0; ?>,
+            sets_dom: <?php echo $liveScoreData['sets_dom'] ?? 0; ?>,
+            sets_ext: <?php echo $liveScoreData['sets_ext'] ?? 0; ?>
+        },
+        isLive: <?php echo json_encode($liveScoreData !== null); ?>,
+        activeLiveScores: [],
+        refreshInterval: null
+    },
+    mounted() {
+        if (this.idMatch) {
+            this.refreshScore();
+            this.startAutoRefresh();
+        } else {
+            this.loadActiveLiveScores();
+            this.refreshInterval = setInterval(() => this.loadActiveLiveScores(), 10000);
+        }
+    },
+    beforeDestroy() {
+        if (this.refreshInterval) {
+            clearInterval(this.refreshInterval);
+        }
+    },
+    methods: {
+        startAutoRefresh() {
+            if (!this.isScorer) {
+                this.refreshInterval = setInterval(() => this.refreshScore(), 5000);
+            }
+        },
+        async refreshScore() {
+            try {
+                const response = await axios.get('/ajax/live_score.php?id_match=' + this.idMatch);
+                if (response.data.success && response.data.data) {
+                    this.score = response.data.data;
+                    this.isLive = true;
+                } else {
+                    this.isLive = false;
+                }
+            } catch (error) {
+                console.error('Error refreshing score:', error);
+            }
+        },
+        async loadActiveLiveScores() {
+            try {
+                const response = await axios.get('/ajax/live_score.php');
+                if (response.data.success) {
+                    this.activeLiveScores = response.data.data;
+                }
+            } catch (error) {
+                console.error('Error loading active live scores:', error);
+            }
+        },
+        async startLiveScore() {
+            console.log('Starting live score with idMatch:', this.idMatch);
+            try {
+                const response = await axios.post('/ajax/live_score.php', {
+                    action: 'start',
+                    id_match: this.idMatch
+                });
+                if (response.data.success) {
+                    this.isLive = true;
+                    this.showToast('Live score démarré !', 'success');
+                }
+            } catch (error) {
+                this.showToast('Erreur: ' + error.response?.data?.error, 'error');
+            }
+        },
+        async incrementScore(team) {
+            try {
+                const response = await axios.post('/ajax/live_score.php', {
+                    action: 'increment',
+                    id_match: this.idMatch,
+                    team: team
+                });
+                if (response.data.success) {
+                    this.score = response.data.data;
+                }
+            } catch (error) {
+                this.showToast('Erreur: ' + error.response?.data?.error, 'error');
+            }
+        },
+        async decrementScore(team) {
+            try {
+                const response = await axios.post('/ajax/live_score.php', {
+                    action: 'decrement',
+                    id_match: this.idMatch,
+                    team: team
+                });
+                if (response.data.success) {
+                    this.score = response.data.data;
+                }
+            } catch (error) {
+                this.showToast('Erreur: ' + error.response?.data?.error, 'error');
+            }
+        },
+        async nextSet(winner) {
+            try {
+                const response = await axios.post('/ajax/live_score.php', {
+                    action: 'next_set',
+                    id_match: this.idMatch,
+                    set_winner: winner
+                });
+                if (response.data.success) {
+                    this.score = response.data.data;
+                    this.showToast('Set terminé !', 'success');
+                }
+            } catch (error) {
+                this.showToast('Erreur: ' + error.response?.data?.error, 'error');
+            }
+        },
+        async endLiveScore() {
+            if (!confirm('Êtes-vous sûr de vouloir terminer le live score ?')) return;
+            try {
+                const response = await axios.post('/ajax/live_score.php', {
+                    action: 'end',
+                    id_match: this.idMatch
+                });
+                if (response.data.success) {
+                    this.isLive = false;
+                    this.showToast('Live score terminé', 'info');
+                }
+            } catch (error) {
+                this.showToast('Erreur: ' + error.response?.data?.error, 'error');
+            }
+        },
+        async saveToMatch() {
+            if (!confirm('Enregistrer les scores dans le match ? Cette action terminera le live score.')) return;
+            try {
+                const response = await axios.post('/ajax/live_score.php', {
+                    action: 'save_to_match',
+                    id_match: this.idMatch
+                });
+                if (response.data.success) {
+                    this.isLive = false;
+                    this.showToast('Scores enregistrés dans le match !', 'success');
+                }
+            } catch (error) {
+                this.showToast('Erreur: ' + error.response?.data?.error, 'error');
+            }
+        },
+        showToast(message, type = 'info') {
+            const colors = {
+                success: '#10b981',
+                error: '#ef4444',
+                info: '#3b82f6'
+            };
+            Toastify({
+                text: message,
+                duration: 3000,
+                gravity: "top",
+                position: "center",
+                backgroundColor: colors[type] || colors.info
+            }).showToast();
+        }
+    }
+});
+</script>
+</BODY>
+</HTML>

--- a/match.js
+++ b/match.js
@@ -19,6 +19,22 @@ new Vue({
             const allowedProfiles = ["RESPONSABLE_EQUIPE"];
             return this.user && allowedProfiles.includes(this.user.profile_name);
         },
+        isAdmin() {
+            const allowedProfiles = ["ADMINISTRATEUR", "SUPPORT"];
+            return this.user && allowedProfiles.includes(this.user.profile_name);
+        },
+        isMatchDay() {
+            if (!this.matchData.date_reception) return false;
+            const today = new Date().toLocaleDateString('fr-FR');
+            return this.matchData.date_reception === today;
+        },
+        canScoreLive() {
+            if (!this.user) return false;
+            if (this.isAdmin) return true;
+            if (!this.isLeader) return false;
+            const userTeamId = this.user.id_equipe;
+            return userTeamId == this.matchData.id_equipe_dom || userTeamId == this.matchData.id_equipe_ext;
+        },
     },
     methods: {
         reloadData() {

--- a/pages/components/card/Match.js
+++ b/pages/components/card/Match.js
@@ -126,6 +126,12 @@ export default {
           <span class="badge badge-error" v-if="match.is_forfait === 1">forfait</span>
         </p>
         <p>Date : {{ match.date_reception }}</p>
+        <div v-if="isMatchToday && !isMatchFinished" class="mt-2">
+          <a :href="'/live.php?id_match=' + match.code_match + '&mode=scorer'" 
+             class="btn btn-warning btn-sm animate-pulse" target="_blank">
+            <i class="fas fa-edit mr-1"></i>Mode scoreur
+          </a>
+        </div>
         <div v-if="!['null', '', null].includes(match.note)" class="collapse">
           <input type="checkbox"/>
           <div class="collapse-title text-xs font-medium">voir les commentaires</div>
@@ -149,6 +155,14 @@ export default {
             const today = new Date();
             today.setHours(0, 0, 0, 0);
             return matchDate <= today;
+        },
+        isMatchToday() {
+            if (!this.match.date_reception) return false;
+            const today = new Date().toLocaleDateString('fr-FR');
+            return this.match.date_reception === today;
+        },
+        isMatchFinished() {
+            return this.match.score_equipe_dom === 3 || this.match.score_equipe_ext === 3;
         }
     },
     methods: {

--- a/pages/components/table/Matchs.js
+++ b/pages/components/table/Matchs.js
@@ -27,6 +27,10 @@ export default {
                  title="Ajouter à Google Calendar">
                 <i class="fas fa-calendar-plus"/>
               </a>
+              <a v-if="isMatchToday(match) && !isMatchFinished(match)" :href="'/live.php?id_match=' + match.code_match" 
+                 class="btn btn-xs btn-error ml-2 animate-pulse" title="Suivre en direct" target="_blank">
+                <i class="fas fa-circle text-white text-xs mr-1"/>LIVE
+              </a>
               <i v-if="match.certif === 1" class="fas fa-check-circle text-success ml-2" title="Match validé"></i>
             </td>
             <td>{{ match.date_reception }} {{ match.heure_reception }}<span v-if="match.match_status == 'NOT_CONFIRMED'"
@@ -102,6 +106,14 @@ export default {
         },
         resetFilters() {
             this.resetBaseFilters();
+        },
+        isMatchToday(match) {
+            if (!match.date_reception) return false;
+            const today = new Date().toLocaleDateString('fr-FR');
+            return match.date_reception === today;
+        },
+        isMatchFinished(match) {
+            return match.score_equipe_dom === 3 || match.score_equipe_ext === 3;
         },
         addToGoogleCalendar(match) {
             // Convertir le timestamp en date

--- a/unit_tests/LiveScoreTest.php
+++ b/unit_tests/LiveScoreTest.php
@@ -1,0 +1,181 @@
+<?php
+
+require_once __DIR__ . '/../classes/LiveScore.php';
+require_once __DIR__ . '/../classes/SqlManager.php';
+require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/UfolepTestCase.php';
+
+class LiveScoreTest extends UfolepTestCase
+{
+    private $liveScore;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->liveScore = new LiveScore();
+        $this->connect_as_admin();
+    }
+
+    public function test_get_live_score_returns_null_when_no_live_score_exists()
+    {
+        $result = $this->liveScore->getLiveScore(999999);
+        $this->assertNull($result);
+    }
+
+    public function test_start_live_score_creates_new_entry()
+    {
+        // Get a valid match id from the database
+        $matches = $this->sql->execute("SELECT id_match FROM matches LIMIT 1");
+        if (empty($matches)) {
+            $this->markTestSkipped('No matches in database');
+        }
+        $id_match = $matches[0]['id_match'];
+
+        $result = $this->liveScore->startLiveScore($id_match);
+        $this->assertNotEmpty($result);
+
+        // Verify entry was created
+        $liveScore = $this->liveScore->getLiveScore($id_match);
+        $this->assertNotNull($liveScore);
+        $this->assertEquals($id_match, $liveScore['id_match']);
+        $this->assertEquals(1, $liveScore['set_en_cours']);
+        $this->assertEquals(0, $liveScore['score_dom']);
+        $this->assertEquals(0, $liveScore['score_ext']);
+
+        // Cleanup
+        $this->liveScore->deleteLiveScore($id_match);
+    }
+
+    public function test_increment_score_dom()
+    {
+        $matches = $this->sql->execute("SELECT id_match FROM matches LIMIT 1");
+        if (empty($matches)) {
+            $this->markTestSkipped('No matches in database');
+        }
+        $id_match = $matches[0]['id_match'];
+
+        // Start a live score
+        $this->liveScore->startLiveScore($id_match);
+
+        // Increment dom score
+        $this->liveScore->incrementScore($id_match, 'dom');
+
+        $liveScore = $this->liveScore->getLiveScore($id_match);
+        $this->assertEquals(1, $liveScore['score_dom']);
+        $this->assertEquals(0, $liveScore['score_ext']);
+
+        // Cleanup
+        $this->liveScore->deleteLiveScore($id_match);
+    }
+
+    public function test_increment_score_ext()
+    {
+        $matches = $this->sql->execute("SELECT id_match FROM matches LIMIT 1");
+        if (empty($matches)) {
+            $this->markTestSkipped('No matches in database');
+        }
+        $id_match = $matches[0]['id_match'];
+
+        // Start a live score
+        $this->liveScore->startLiveScore($id_match);
+
+        // Increment ext score
+        $this->liveScore->incrementScore($id_match, 'ext');
+
+        $liveScore = $this->liveScore->getLiveScore($id_match);
+        $this->assertEquals(0, $liveScore['score_dom']);
+        $this->assertEquals(1, $liveScore['score_ext']);
+
+        // Cleanup
+        $this->liveScore->deleteLiveScore($id_match);
+    }
+
+    public function test_next_set_increments_set_and_resets_scores()
+    {
+        $matches = $this->sql->execute("SELECT id_match FROM matches LIMIT 1");
+        if (empty($matches)) {
+            $this->markTestSkipped('No matches in database');
+        }
+        $id_match = $matches[0]['id_match'];
+
+        // Start a live score and add some points
+        $this->liveScore->startLiveScore($id_match);
+        $this->liveScore->incrementScore($id_match, 'dom');
+        $this->liveScore->incrementScore($id_match, 'dom');
+        $this->liveScore->incrementScore($id_match, 'ext');
+
+        // Go to next set
+        $this->liveScore->nextSet($id_match);
+
+        $liveScore = $this->liveScore->getLiveScore($id_match);
+        $this->assertEquals(2, $liveScore['set_en_cours']);
+        $this->assertEquals(0, $liveScore['score_dom']);
+        $this->assertEquals(0, $liveScore['score_ext']);
+
+        // Cleanup
+        $this->liveScore->deleteLiveScore($id_match);
+    }
+
+    public function test_decrement_score_dom()
+    {
+        $matches = $this->sql->execute("SELECT id_match FROM matches LIMIT 1");
+        if (empty($matches)) {
+            $this->markTestSkipped('No matches in database');
+        }
+        $id_match = $matches[0]['id_match'];
+
+        // Start a live score and add points
+        $this->liveScore->startLiveScore($id_match);
+        $this->liveScore->incrementScore($id_match, 'dom');
+        $this->liveScore->incrementScore($id_match, 'dom');
+
+        // Decrement
+        $this->liveScore->decrementScore($id_match, 'dom');
+
+        $liveScore = $this->liveScore->getLiveScore($id_match);
+        $this->assertEquals(1, $liveScore['score_dom']);
+
+        // Cleanup
+        $this->liveScore->deleteLiveScore($id_match);
+    }
+
+    public function test_decrement_score_cannot_go_below_zero()
+    {
+        $matches = $this->sql->execute("SELECT id_match FROM matches LIMIT 1");
+        if (empty($matches)) {
+            $this->markTestSkipped('No matches in database');
+        }
+        $id_match = $matches[0]['id_match'];
+
+        // Start a live score
+        $this->liveScore->startLiveScore($id_match);
+
+        // Try to decrement from 0
+        $this->liveScore->decrementScore($id_match, 'dom');
+
+        $liveScore = $this->liveScore->getLiveScore($id_match);
+        $this->assertEquals(0, $liveScore['score_dom']);
+
+        // Cleanup
+        $this->liveScore->deleteLiveScore($id_match);
+    }
+
+    public function test_get_active_live_scores()
+    {
+        $matches = $this->sql->execute("SELECT id_match FROM matches LIMIT 2");
+        if (count($matches) < 2) {
+            $this->markTestSkipped('Not enough matches in database');
+        }
+
+        // Start 2 live scores
+        $this->liveScore->startLiveScore($matches[0]['id_match']);
+        $this->liveScore->startLiveScore($matches[1]['id_match']);
+
+        $activeLiveScores = $this->liveScore->getActiveLiveScores();
+        $this->assertGreaterThanOrEqual(2, count($activeLiveScores));
+
+        // Cleanup
+        $this->liveScore->deleteLiveScore($matches[0]['id_match']);
+        $this->liveScore->deleteLiveScore($matches[1]['id_match']);
+    }
+}


### PR DESCRIPTION
## Description
Implémentation du suivi en direct des scores de matchs.

## Fonctionnalités
- Table live_scores pour stocker les scores en temps réel
- API REST (/ajax/live_score.php) pour gérer les scores
- Interface Vue.js (live.php) pour scoreur et spectateur
- Stockage des scores par set (set_1_dom, set_1_ext, etc.)
- Bouton 'Renseigner les scores' pour sauvegarder dans matches
- Bouton LIVE animé dans la table des matchs (jour du match uniquement)
- Bouton Mode scoreur sur les cartes de match (my_page)
- Autorisation: admin ou responsable d'équipe du match
- Masquage des boutons si match terminé

## Tests
- Unit tests PHPUnit pour LiveScore class

Closes #186