### PR TITLE
Feature #38: Agir en tant que... pour les admins

### DIFF
--- a/js/administration.js
+++ b/js/administration.js
@@ -24,6 +24,7 @@ Ext.application({
         'manage_commission',
         'manage_registry',
         'manage_user',
+        'act_as',
     ],
     name: 'Ufolep13Volley',
     appFolder: 'js',
@@ -167,6 +168,13 @@ Ext.application({
                                         action: 'displayBlacklistDate'
                                     }
                                 ]
+                            },
+                            {
+                                xtype: 'button',
+                                text: 'Agir en tant que...',
+                                scale: 'medium',
+                                glyph: 'xf21b@FontAwesome',
+                                action: 'showActAsSelector'
                             },
                             '->',
                             {

--- a/js/controller/act_as.js
+++ b/js/controller/act_as.js
@@ -1,0 +1,108 @@
+Ext.define('Ufolep13Volley.controller.act_as', {
+    extend: 'Ext.app.Controller',
+    stores: ['ActAs'],
+    init: function () {
+        this.control({
+            'button[action=showActAsSelector]': {
+                click: this.showActAsSelector
+            }
+        });
+    },
+
+    showActAsSelector: function () {
+        var store = Ext.create('Ufolep13Volley.store.ActAs');
+        store.load({
+            callback: function (records, operation, success) {
+                if (!success) {
+                    Ext.Msg.alert('Erreur', 'Impossible de charger la liste des utilisateurs');
+                    return;
+                }
+                
+                var win = Ext.create('Ext.window.Window', {
+                    title: 'Agir en tant que...',
+                    modal: true,
+                    width: 500,
+                    height: 400,
+                    layout: 'fit',
+                    items: [{
+                        xtype: 'grid',
+                        store: store,
+                        columns: [
+                            {text: 'Login', dataIndex: 'login', flex: 1},
+                            {text: 'Email', dataIndex: 'email', flex: 1},
+                            {text: 'Profil', dataIndex: 'profile_name', width: 120},
+                            {text: 'Équipes', dataIndex: 'equipes', flex: 1}
+                        ],
+                        listeners: {
+                            itemdblclick: function (grid, record) {
+                                Ext.Msg.confirm(
+                                    'Confirmation',
+                                    'Voulez-vous agir en tant que <b>' + record.get('login') + '</b> ?',
+                                    function (btn) {
+                                        if (btn === 'yes') {
+                                            Ext.Ajax.request({
+                                                url: '/rest/action.php/usermanager/switch_to_user',
+                                                method: 'POST',
+                                                params: {
+                                                    target_user_id: record.get('id')
+                                                },
+                                                success: function (response) {
+                                                    var result = Ext.decode(response.responseText);
+                                                    if (result.success) {
+                                                        Ext.Msg.alert('Succès', 'Vous agissez maintenant en tant que ' + record.get('login'), function () {
+                                                            window.location.href = '/pages/home.html';
+                                                        });
+                                                    } else {
+                                                        Ext.Msg.alert('Erreur', result.message);
+                                                    }
+                                                },
+                                                failure: function () {
+                                                    Ext.Msg.alert('Erreur', 'Erreur de communication avec le serveur');
+                                                }
+                                            });
+                                            win.close();
+                                        }
+                                    }
+                                );
+                            }
+                        },
+                        dockedItems: [{
+                            xtype: 'toolbar',
+                            dock: 'top',
+                            items: [{
+                                xtype: 'textfield',
+                                emptyText: 'Rechercher un utilisateur...',
+                                width: 300,
+                                listeners: {
+                                    change: function (field, newValue) {
+                                        var grid = field.up('grid');
+                                        var store = grid.getStore();
+                                        store.clearFilter();
+                                        if (newValue) {
+                                            store.filterBy(function (record) {
+                                                var login = record.get('login') || '';
+                                                var email = record.get('email') || '';
+                                                var equipes = record.get('equipes') || '';
+                                                var searchValue = newValue.toLowerCase();
+                                                return login.toLowerCase().indexOf(searchValue) !== -1 ||
+                                                       email.toLowerCase().indexOf(searchValue) !== -1 ||
+                                                       equipes.toLowerCase().indexOf(searchValue) !== -1;
+                                            });
+                                        }
+                                    }
+                                }
+                            }]
+                        }]
+                    }],
+                    buttons: [{
+                        text: 'Annuler',
+                        handler: function () {
+                            win.close();
+                        }
+                    }]
+                });
+                win.show();
+            }
+        });
+    }
+});

--- a/js/store/ActAs.js
+++ b/js/store/ActAs.js
@@ -1,0 +1,13 @@
+Ext.define('Ufolep13Volley.store.ActAs', {
+    extend: 'Ext.data.Store',
+    storeId: 'ActAs',
+    fields: ['id', 'login', 'email', 'profile_name', 'equipes'],
+    proxy: {
+        type: 'ajax',
+        url: '/rest/action.php/usermanager/get_users_for_act_as',
+        reader: {
+            type: 'json'
+        }
+    },
+    autoLoad: false
+});

--- a/pages/components/navbar/Main.js
+++ b/pages/components/navbar/Main.js
@@ -146,14 +146,23 @@ export default {
               <li><a href="/infos_utiles/Media/ReglementIsoardi.pdf" target="_blank"><i class="fas fa-link mr-2"/>Coupe Isoardi</a></li>
             </ul>
           </div>
+          <div v-if="isActingAs" class="flex gap-1 items-center">
+            <div class="badge badge-warning gap-2 animate-pulse">
+              <i class="fas fa-user-secret"/>
+              Mode: {{ this.user.login }}
+            </div>
+            <button class="btn btn-warning btn-sm" @click="switchBackToAdmin">
+              <i class="fas fa-arrow-left mr-1"/>Retour Admin
+            </button>
+          </div>
           <div v-if="isConnected" class="flex gap-1">
             <a class="btn btn-primary"
-               v-if="['ADMINISTRATEUR', 'COMMISSION', 'SUPPORT'].includes(this.user.profile_name)"
+               v-if="['ADMINISTRATEUR', 'COMMISSION', 'SUPPORT'].includes(this.user.profile_name) && !isActingAs"
                href="/admin.php">
               <span><i class="fas fa-gear mr-2"/>administration</span>
             </a>
             <a class="btn btn-primary"
-               v-if="!['ADMINISTRATEUR', 'COMMISSION', 'SUPPORT'].includes(this.user.profile_name)"
+               v-if="!['ADMINISTRATEUR', 'COMMISSION', 'SUPPORT'].includes(this.user.profile_name) || isActingAs"
                href="/pages/my_page.html">
               <span><i class="fas fa-user mr-2"/>{{ this.user.login }}</span>
             </a>
@@ -213,6 +222,9 @@ export default {
         }, isConnected() {
             return this.user !== null;
         },
+        isActingAs() {
+            return this.user !== null && this.user.is_acting_as === true;
+        },
     },
     methods: {
         fetch() {
@@ -236,6 +248,21 @@ export default {
                 })
                 .catch((error) => {
                     console.log(error)
+                });
+        },
+        switchBackToAdmin() {
+            axios
+                .post("/rest/action.php/usermanager/switch_back_to_admin")
+                .then((response) => {
+                    if (response.data.success) {
+                        window.location.href = '/admin.php';
+                    } else {
+                        alert('Erreur: ' + response.data.message);
+                    }
+                })
+                .catch((error) => {
+                    console.error("Erreur lors du retour admin:", error);
+                    alert('Erreur de communication avec le serveur');
                 });
         },
     },

--- a/session_user.php
+++ b/session_user.php
@@ -5,5 +5,10 @@ if (!UserManager::is_connected()) {
     exit;
 }
 header('Content-Type: application/json');
-echo json_encode($_SESSION);
+$response = $_SESSION;
+$response['is_acting_as'] = UserManager::is_acting_as();
+if (UserManager::is_acting_as()) {
+    $response['original_admin'] = UserManager::get_original_admin();
+}
+echo json_encode($response);
 ?>

--- a/unit_tests/ActAsTest.php
+++ b/unit_tests/ActAsTest.php
@@ -1,0 +1,173 @@
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . "/../classes/UserManager.php";
+require_once 'UfolepTestCase.php';
+
+class ActAsTest extends UfolepTestCase
+{
+    private ?int $target_user_id = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        @session_start();
+        $_SESSION = [];
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+        parent::tearDown();
+    }
+
+    private function getTargetUserId(): int
+    {
+        if ($this->target_user_id === null) {
+            $sql = "SELECT ca.id FROM comptes_acces ca 
+                    LEFT JOIN users_profiles up ON up.user_id = ca.id
+                    LEFT JOIN profiles p ON p.id = up.profile_id
+                    WHERE p.name != 'ADMINISTRATEUR' OR p.name IS NULL
+                    LIMIT 1";
+            $results = $this->sql->execute($sql);
+            if (empty($results)) {
+                $this->markTestSkipped("Aucun utilisateur non-admin disponible pour les tests");
+            }
+            $this->target_user_id = (int)$results[0]['id'];
+        }
+        return $this->target_user_id;
+    }
+
+    public function test_switch_to_user_as_admin()
+    {
+        // Arrange
+        $this->connect_as_admin();
+        $manager = new UserManager();
+        $target_user_id = $this->getTargetUserId();
+
+        // Act
+        $result = $manager->switch_to_user($target_user_id);
+
+        // Assert
+        $this->assertTrue($result);
+        $this->assertTrue($_SESSION['acting_as']);
+        $this->assertEquals(1, $_SESSION['original_admin_id']);
+        $this->assertEquals($target_user_id, $_SESSION['id_user']);
+    }
+
+    public function test_switch_to_user_fails_for_non_admin()
+    {
+        // Arrange
+        $this->connect_as_team_leader(5);
+        $manager = new UserManager();
+        $target_user_id = $this->getTargetUserId();
+
+        // Act & Assert
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Seuls les administrateurs peuvent utiliser cette fonctionnalité");
+        $manager->switch_to_user($target_user_id);
+    }
+
+    public function test_switch_back_to_admin()
+    {
+        // Arrange
+        $this->connect_as_admin();
+        $manager = new UserManager();
+        $target_user_id = $this->getTargetUserId();
+        $manager->switch_to_user($target_user_id);
+
+        // Act
+        $result = $manager->switch_back_to_admin();
+
+        // Assert
+        $this->assertTrue($result);
+        $this->assertFalse(isset($_SESSION['acting_as']));
+        $this->assertEquals(1, $_SESSION['id_user']);
+        $this->assertEquals('ADMINISTRATEUR', $_SESSION['profile_name']);
+    }
+
+    public function test_switch_back_fails_when_not_acting_as()
+    {
+        // Arrange
+        $this->connect_as_admin();
+        $manager = new UserManager();
+
+        // Act & Assert
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Vous n'êtes pas en mode 'Agir en tant que'");
+        $manager->switch_back_to_admin();
+    }
+
+    public function test_is_acting_as_returns_true_when_acting()
+    {
+        // Arrange
+        $this->connect_as_admin();
+        $manager = new UserManager();
+        $target_user_id = $this->getTargetUserId();
+        $manager->switch_to_user($target_user_id);
+
+        // Act
+        $result = UserManager::is_acting_as();
+
+        // Assert
+        $this->assertTrue($result);
+    }
+
+    public function test_is_acting_as_returns_false_when_not_acting()
+    {
+        // Arrange
+        $this->connect_as_admin();
+
+        // Act
+        $result = UserManager::is_acting_as();
+
+        // Assert
+        $this->assertFalse($result);
+    }
+
+    public function test_get_original_admin_returns_admin_data()
+    {
+        // Arrange
+        $this->connect_as_admin();
+        $manager = new UserManager();
+        $target_user_id = $this->getTargetUserId();
+        $manager->switch_to_user($target_user_id);
+
+        // Act
+        $result = UserManager::get_original_admin();
+
+        // Assert
+        $this->assertIsArray($result);
+        $this->assertEquals(1, $result['id_user']);
+        $this->assertEquals('test_user', $result['login']);
+        $this->assertEquals('ADMINISTRATEUR', $result['profile_name']);
+    }
+
+    public function test_get_original_admin_returns_null_when_not_acting()
+    {
+        // Arrange
+        $this->connect_as_admin();
+
+        // Act
+        $result = UserManager::get_original_admin();
+
+        // Assert
+        $this->assertNull($result);
+    }
+
+    public function test_get_users_for_act_as_returns_list()
+    {
+        // Arrange
+        $this->connect_as_admin();
+        $manager = new UserManager();
+
+        // Act
+        $result = $manager->get_users_for_act_as();
+
+        // Assert
+        $this->assertIsArray($result);
+        $this->assertNotEmpty($result);
+        $this->assertArrayHasKey('id', $result[0]);
+        $this->assertArrayHasKey('login', $result[0]);
+    }
+}


### PR DESCRIPTION
## Description
Résout #38

Ajout de la fonctionnalité "Agir en tant que..." permettant aux administrateurs de basculer temporairement vers n'importe quel compte utilisateur.

## Changements

### Backend (PHP)
- `UserManager::switch_to_user()` - Basculer vers un autre utilisateur
- `UserManager::switch_back_to_admin()` - Retourner au compte admin
- `UserManager::is_acting_as()` - Vérifier si en mode "Act as"
- `UserManager::get_original_admin()` - Récupérer les infos admin original
- `UserManager::get_users_for_act_as()` - Liste des utilisateurs disponibles
- `session_user.php` - Inclut maintenant le statut is_acting_as

### Frontend (ExtJS Admin)
- Nouveau bouton "Agir en tant que..." dans la toolbar admin
- Fenêtre de sélection d'utilisateur avec recherche
- Controller `act_as.js` et store `ActAs.js`

### Frontend (Vue.js)
- Badge d'alerte visuel quand en mode "Act as"
- Bouton "Retour Admin" pour revenir au compte original
- Adaptation des boutons de navigation selon le mode

## Tests
- [x] Tests unitaires ajoutés (9 tests, 23 assertions)
- [x] Tous les tests passent

## Sécurité
- Seuls les admins peuvent utiliser cette fonctionnalité
- Logging de chaque basculement dans l'activité
- Impossible de basculer si déjà en mode "Act as"

## Checklist
- [x] Code testé localement
- [x] Tests unitaires passent
- [x] Pas de régression sur les tests existants
