### PR TITLE
Feature #188: Gestion des News dans l'admin

### DIFF
--- a/classes/News.php
+++ b/classes/News.php
@@ -32,5 +32,72 @@ class News extends Generic
         return $this->sql_manager->execute($sql);
     }
 
+    public function getAllNews(): array
+    {
+        $sql = "SELECT 
+                n.id,
+                n.title,
+                n.text,
+                n.file_path,
+                DATE_FORMAT(n.news_date, '%Y-%m-%d') AS news_date,
+                n.is_disabled
+            FROM news n
+            ORDER BY n.news_date DESC";
+        return $this->sql_manager->execute($sql);
+    }
+
+    public function saveNews(): void
+    {
+        @session_start();
+        if (!UserManager::isAdmin()) {
+            throw new Exception("Seuls les administrateurs peuvent modifier les news");
+        }
+
+        $id = $_POST['id'] ?? null;
+        $title = $_POST['title'] ?? '';
+        $text = $_POST['text'] ?? '';
+        $file_path = $_POST['file_path'] ?? '';
+        $news_date = $_POST['news_date'] ?? date('Y-m-d');
+        $is_disabled = $_POST['is_disabled'] ?? 0;
+
+        if (!empty($id) && is_numeric($id)) {
+            $sql = "UPDATE news SET title = ?, text = ?, file_path = ?, news_date = ?, is_disabled = ? WHERE id = ?";
+            $bindings = [
+                ['type' => 's', 'value' => $title],
+                ['type' => 's', 'value' => $text],
+                ['type' => 's', 'value' => $file_path],
+                ['type' => 's', 'value' => $news_date],
+                ['type' => 'i', 'value' => $is_disabled],
+                ['type' => 'i', 'value' => $id]
+            ];
+        } else {
+            $sql = "INSERT INTO news (title, text, file_path, news_date, is_disabled) VALUES (?, ?, ?, ?, ?)";
+            $bindings = [
+                ['type' => 's', 'value' => $title],
+                ['type' => 's', 'value' => $text],
+                ['type' => 's', 'value' => $file_path],
+                ['type' => 's', 'value' => $news_date],
+                ['type' => 'i', 'value' => $is_disabled]
+            ];
+        }
+        $this->sql_manager->execute($sql, $bindings);
+    }
+
+    public function deleteNews(): void
+    {
+        @session_start();
+        if (!UserManager::isAdmin()) {
+            throw new Exception("Seuls les administrateurs peuvent supprimer les news");
+        }
+
+        $id = $_POST['id'] ?? null;
+        if (empty($id) || !is_numeric($id)) {
+            throw new Exception("ID de news invalide");
+        }
+
+        $sql = "DELETE FROM news WHERE id = ?";
+        $bindings = [['type' => 'i', 'value' => $id]];
+        $this->sql_manager->execute($sql, $bindings);
+    }
 
 }

--- a/js/administration.js
+++ b/js/administration.js
@@ -166,6 +166,11 @@ Ext.application({
                                     {
                                         text: 'Gestion des dates interdites',
                                         action: 'displayBlacklistDate'
+                                    },
+                                    {
+                                        text: 'Gestion des news',
+                                        glyph: 'xf1ea@FontAwesome',
+                                        action: 'manageNews'
                                     }
                                 ]
                             },

--- a/js/model/News.js
+++ b/js/model/News.js
@@ -1,0 +1,30 @@
+Ext.define('Ufolep13Volley.model.News', {
+    extend: 'Ext.data.Model',
+    fields: [
+        {
+            name: 'id',
+            type: 'int'
+        },
+        {
+            name: 'title',
+            type: 'string'
+        },
+        {
+            name: 'text',
+            type: 'string'
+        },
+        {
+            name: 'file_path',
+            type: 'string'
+        },
+        {
+            name: 'news_date',
+            type: 'date',
+            dateFormat: 'Y-m-d'
+        },
+        {
+            name: 'is_disabled',
+            type: 'int'
+        }
+    ]
+});

--- a/js/store/AdminNews.js
+++ b/js/store/AdminNews.js
@@ -1,0 +1,15 @@
+Ext.define('Ufolep13Volley.store.AdminNews', {
+    extend: 'Ext.data.Store',
+    alias: 'store.AdminNews',
+    config: {
+        model: 'Ufolep13Volley.model.News',
+        proxy: {
+            type: 'ajax',
+            url: '/rest/action.php/news/getAllNews',
+            reader: {
+                type: 'json'
+            }
+        },
+        autoLoad: true
+    }
+});

--- a/js/view/news/AdminGrid.js
+++ b/js/view/news/AdminGrid.js
@@ -1,0 +1,93 @@
+Ext.define('Ufolep13Volley.view.news.AdminGrid', {
+    extend: 'Ufolep13Volley.view.grid.ufolep',
+    alias: 'widget.newsgrid',
+    title: 'Gestion des News',
+    store: {type: 'AdminNews'},
+    plugins: [{
+        ptype: 'rowediting',
+        clicksToEdit: 2,
+        pluginId: 'rowediting'
+    }],
+    columns: {
+        items: [
+            {
+                header: 'ID',
+                dataIndex: 'id',
+                width: 60
+            },
+            {
+                header: 'Titre',
+                dataIndex: 'title',
+                flex: 1,
+                editor: {
+                    xtype: 'textfield',
+                    allowBlank: false
+                }
+            },
+            {
+                header: 'Texte',
+                dataIndex: 'text',
+                flex: 2,
+                editor: {
+                    xtype: 'textarea',
+                    allowBlank: true
+                }
+            },
+            {
+                header: 'Fichier',
+                dataIndex: 'file_path',
+                width: 150,
+                editor: {
+                    xtype: 'textfield',
+                    allowBlank: true
+                }
+            },
+            {
+                header: 'Date',
+                dataIndex: 'news_date',
+                width: 120,
+                renderer: Ext.util.Format.dateRenderer('d/m/Y'),
+                editor: {
+                    xtype: 'datefield',
+                    format: 'd/m/Y',
+                    allowBlank: false
+                }
+            },
+            {
+                header: 'Désactivé',
+                dataIndex: 'is_disabled',
+                width: 100,
+                renderer: function(value) {
+                    return value == 1 ? 'Oui' : 'Non';
+                },
+                editor: {
+                    xtype: 'combobox',
+                    store: [[0, 'Non'], [1, 'Oui']],
+                    editable: false
+                }
+            }
+        ]
+    },
+    dockedItems: [
+        {
+            xtype: 'toolbar',
+            dock: 'top',
+            items: [
+                'ACTIONS',
+                {
+                    xtype: 'tbseparator'
+                },
+                {
+                    text: 'Ajouter une news',
+                    glyph: 'xf067@FontAwesome',
+                    action: 'addNews'
+                },
+                {
+                    text: 'Supprimer',
+                    glyph: 'xf1f8@FontAwesome',
+                    action: 'deleteNews'
+                }
+            ]
+        }
+    ]
+});

--- a/unit_tests/NewsTest.php
+++ b/unit_tests/NewsTest.php
@@ -1,0 +1,174 @@
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . "/../classes/News.php";
+require_once 'UfolepTestCase.php';
+
+class NewsTest extends UfolepTestCase
+{
+    private ?int $created_news_id = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        @session_start();
+        $_SESSION = [];
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->created_news_id !== null) {
+            $sql = "DELETE FROM news WHERE id = ?";
+            $bindings = [['type' => 'i', 'value' => $this->created_news_id]];
+            $this->sql->execute($sql, $bindings);
+            $this->created_news_id = null;
+        }
+        $_SESSION = [];
+        parent::tearDown();
+    }
+
+    public function test_getAllNews_returns_array()
+    {
+        // Arrange
+        $this->connect_as_admin();
+        $manager = new News();
+
+        // Act
+        $result = $manager->getAllNews();
+
+        // Assert
+        $this->assertIsArray($result);
+    }
+
+    public function test_getAllNews_includes_disabled_news()
+    {
+        // Arrange
+        $this->connect_as_admin();
+        $manager = new News();
+        
+        // Create a disabled news for testing
+        $sql = "INSERT INTO news (title, text, file_path, news_date, is_disabled) VALUES (?, ?, '', NOW(), 1)";
+        $bindings = [
+            ['type' => 's', 'value' => 'Test News Disabled'],
+            ['type' => 's', 'value' => 'Test content disabled']
+        ];
+        $this->created_news_id = $this->sql->execute($sql, $bindings);
+
+        // Act
+        $result = $manager->getAllNews();
+
+        // Assert
+        $found = false;
+        foreach ($result as $news) {
+            if ($news['id'] == $this->created_news_id) {
+                $found = true;
+                break;
+            }
+        }
+        $this->assertTrue($found, "getAllNews should include disabled news");
+    }
+
+    public function test_saveNews_creates_new_news()
+    {
+        // Arrange
+        $this->connect_as_admin();
+        $manager = new News();
+        $_POST['title'] = 'Test New News';
+        $_POST['text'] = 'Test content for new news';
+        $_POST['news_date'] = date('Y-m-d');
+        $_POST['is_disabled'] = 0;
+
+        // Act
+        $manager->saveNews();
+        
+        // Get the created news
+        $sql = "SELECT id FROM news WHERE title = ? ORDER BY id DESC LIMIT 1";
+        $bindings = [['type' => 's', 'value' => 'Test New News']];
+        $result = $this->sql->execute($sql, $bindings);
+        $this->created_news_id = (int)$result[0]['id'];
+
+        // Assert
+        $this->assertNotNull($this->created_news_id);
+    }
+
+    public function test_saveNews_updates_existing_news()
+    {
+        // Arrange
+        $this->connect_as_admin();
+        $manager = new News();
+        
+        // Create a news first
+        $sql = "INSERT INTO news (title, text, file_path, news_date, is_disabled) VALUES (?, ?, '', NOW(), 0)";
+        $bindings = [
+            ['type' => 's', 'value' => 'Original Title'],
+            ['type' => 's', 'value' => 'Original content']
+        ];
+        $this->created_news_id = $this->sql->execute($sql, $bindings);
+
+        // Act - Update the news
+        $_POST['id'] = $this->created_news_id;
+        $_POST['title'] = 'Updated Title';
+        $_POST['text'] = 'Updated content';
+        $_POST['news_date'] = date('Y-m-d');
+        $_POST['is_disabled'] = 0;
+        $manager->saveNews();
+
+        // Assert
+        $sql = "SELECT title FROM news WHERE id = ?";
+        $bindings = [['type' => 'i', 'value' => $this->created_news_id]];
+        $result = $this->sql->execute($sql, $bindings);
+        $this->assertEquals('Updated Title', $result[0]['title']);
+    }
+
+    public function test_deleteNews_removes_news()
+    {
+        // Arrange
+        $this->connect_as_admin();
+        $manager = new News();
+        
+        // Create a news first
+        $sql = "INSERT INTO news (title, text, file_path, news_date, is_disabled) VALUES (?, ?, '', NOW(), 0)";
+        $bindings = [
+            ['type' => 's', 'value' => 'To Delete'],
+            ['type' => 's', 'value' => 'Content to delete']
+        ];
+        $news_id = $this->sql->execute($sql, $bindings);
+
+        // Act
+        $_POST['id'] = $news_id;
+        $manager->deleteNews();
+
+        // Assert
+        $sql = "SELECT id FROM news WHERE id = ?";
+        $bindings = [['type' => 'i', 'value' => $news_id]];
+        $result = $this->sql->execute($sql, $bindings);
+        $this->assertEmpty($result);
+    }
+
+    public function test_saveNews_fails_for_non_admin()
+    {
+        // Arrange
+        $this->connect_as_team_leader(5);
+        $manager = new News();
+        $_POST['title'] = 'Test News';
+        $_POST['text'] = 'Test content';
+        $_POST['news_date'] = date('Y-m-d');
+        $_POST['is_disabled'] = 0;
+
+        // Act & Assert
+        $this->expectException(Exception::class);
+        $manager->saveNews();
+    }
+
+    public function test_deleteNews_fails_for_non_admin()
+    {
+        // Arrange
+        $this->connect_as_team_leader(5);
+        $manager = new News();
+        $_POST['id'] = 1;
+
+        // Act & Assert
+        $this->expectException(Exception::class);
+        $manager->deleteNews();
+    }
+}


### PR DESCRIPTION
## Description
Résout #188

Implémentation de l'édition en ligne de la table News via l'interface d'administration ExtJS.

## Changements

### Backend (PHP)
- `News::getAllNews()` - Récupérer toutes les news (y compris désactivées)
- `News::saveNews()` - Créer/modifier une news
- `News::deleteNews()` - Supprimer une news

### Frontend (ExtJS)
- `js/model/News.js` - Modèle de données News
- `js/store/AdminNews.js` - Store pour charger les news
- `js/view/news/AdminGrid.js` - Grille avec édition en ligne (RowEditing)
- Menu "Gestion des news" dans administration.js
- Méthodes controller: showNewsGrid, addNews, deleteNews, saveNews

## Tests
- [x] 7 tests unitaires ajoutés
- [x] Tous les tests passent

## Fonctionnalités
- [x] L'admin peut voir toutes les news (actives et désactivées)
- [x] L'admin peut ajouter une nouvelle news
- [x] L'admin peut modifier une news existante en ligne
- [x] L'admin peut supprimer une news
- [x] L'admin peut activer/désactiver une news

## Sécurité
- Seuls les admins peuvent créer/modifier/supprimer les news
- Vérification du profil dans les méthodes PHP
