### PR TITLE
Fix #196: Dissocier saisie du score et enregistrement (autosave / réseau instable)

### DIFF
--- a/ajax/live_score.php
+++ b/ajax/live_score.php
@@ -129,6 +129,20 @@ try {
                 ]);
                 break;
 
+            case 'upsert':
+                if (!isset($input['score_data']) || !is_array($input['score_data'])) {
+                    throw new Exception("Missing or invalid score_data parameter");
+                }
+                if (!isset($input['version']) || !is_numeric($input['version'])) {
+                    throw new Exception("Missing or invalid version parameter");
+                }
+                $result = $liveScore->upsertScore($id_match, $input['score_data'], (int)$input['version']);
+                if (!$result['success']) {
+                    http_response_code(409);
+                }
+                echo json_encode($result);
+                break;
+
             case 'save_to_match':
                 $liveScore->saveToMatch($id_match);
                 echo json_encode([


### PR DESCRIPTION
## Description
Résout #196

Dissocie la saisie du score et l'enregistrement en mode scoreur dans `live.php`, pour gérer les réseaux instables en gymnase.

## Changements

### Backend
- **`classes/LiveScore.php`** : ajout méthode `upsertScore()` — upsert idempotent avec contrôle de concurrence optimiste via colonne `version`
- **`ajax/live_score.php`** : ajout action `upsert` qui accepte l'état complet du score + version
- **SQL** : migration `004-add_version_to_live_scores.sql` (colonne `version INT NOT NULL DEFAULT 1`)

### Frontend (`live.php`)
- Les boutons +1/-1 et "Set gagné" modifient l'état **local** uniquement (plus d'AJAX à chaque clic)
- **Indicateur de statut** visible : Enregistré / Non enregistré / Enregistrement en cours / Échec
- **Autosave** toutes les 5s si changements pendants
- **Retry avec backoff exponentiel** en cas d'échec réseau (jusqu'à 5 tentatives)
- **Persistance localStorage** du brouillon (survie refresh/crash, restauration automatique)
- **Détection online/offline** : flush automatique au retour du réseau
- **Résolution conflits de version** : adoption automatique de l'état serveur en cas de conflit
- Boutons manuels "Enregistrer" et "Réessayer"

## Tests
- [x] 5 tests unitaires ajoutés pour `upsertScore` (état complet, incrément version, rejet version périmée, retour état serveur sur conflit, version initiale)
- [x] Tous les tests passent (13/13)

## Checklist
- [x] Code review demandée
- [x] Tests unitaires ajoutés
- [x] Migration SQL commitée dans ufolep13volley_python
