### PR TITLE
refactor: make unit tests non-destructive and remove obsolete match generation tests

### DIFF
--- a/unit_tests/ActAsTest.php
+++ b/unit_tests/ActAsTest.php
@@ -11,14 +11,6 @@ class ActAsTest extends UfolepTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        @session_start();
-        $_SESSION = [];
-    }
-
-    protected function tearDown(): void
-    {
-        $_SESSION = [];
-        parent::tearDown();
     }
 
     private function getTargetUserId(): int

--- a/unit_tests/CompetitionTest.php
+++ b/unit_tests/CompetitionTest.php
@@ -5,50 +5,15 @@ require_once __DIR__ . '/../vendor/autoload.php';
 require_once 'UfolepTestCase.php';
 
 require_once __DIR__ . "/../classes/Competition.php";
-require_once __DIR__ . "/../classes/Day.php";
 
 class CompetitionTest extends UfolepTestCase
 {
     private Competition $competition;
 
-    private function init_m_classements() {
-        // initial conditions:
-        // - remove all 'm' teams from classements
-        $this->sql->execute("DELETE FROM classements WHERE code_competition ='m'");
-        // - pick 10 teams from 'm' with is_cup_registered = 1, and add them to classements
-        // - 5 teams in division 1 with rank_start 1-5, and 5 teams in division 2 with rank_start 1-5
-        $sql = "INSERT INTO classements(code_competition, division, id_equipe, rank_start) 
-                SELECT 'm', 
-                       CASE WHEN row_num <= 5 THEN '1' ELSE '2' END as division, 
-                       id_equipe, 
-                       CASE WHEN row_num <= 5 THEN row_num ELSE row_num - 5 END as rank_start
-                FROM (
-                    SELECT id_equipe, @row_number := @row_number + 1 as row_num
-                    FROM equipes, (SELECT @row_number := 0) as r
-                    WHERE code_competition = 'm' AND is_cup_registered = 1
-                    LIMIT 10
-                ) as numbered_teams";
-        $this->sql->execute($sql);
-
-    }
-
     protected function setUp(): void
     {
         parent::setUp();
         $this->competition = new Competition();
-        $this->day = new Day();
-        $this->limit_date = new LimitDate();
-        $this->match = new MatchMgr();
-    }
-
-    /**
-     * @throws Exception
-     */
-    public function testInit_classements_isoardi()
-    {
-        $this->init_m_classements();
-        $this->competition->init_classements_isoardi(true);
-        $this->assertTrue(1 == 1);
     }
 
     /**
@@ -63,77 +28,6 @@ class CompetitionTest extends UfolepTestCase
         foreach (array('c', 'cf', 'kh', 'kf') as $code) {
             $comp = $this->competition->getCompetition($code);
             $this->assertFalse($this->competition->is_championship($comp['id']));
-        }
-    }
-
-    /**
-     * @throws Exception
-     */
-    public function test_is_first_half()
-    {
-        foreach (array('m', 'f', 'mo') as $code) {
-            $comp = $this->competition->getCompetition($code);
-            $inputs = array(
-                'id' => $comp['id'],
-                'start_date' => '07/11/2024',
-            );
-            $this->competition->save($inputs);
-            $this->assertTrue($this->competition->is_first_half($comp['id']));
-        }
-        foreach (array('c', 'kh') as $code) {
-            $comp = $this->competition->getCompetition($code);
-            $inputs = array(
-                'id' => $comp['id'],
-                'start_date' => '07/03/2025',
-            );
-            $this->competition->save($inputs);
-            $this->assertFalse($this->competition->is_first_half($comp['id']));
-        }
-    }
-
-
-    /**
-     * @throws Exception
-     */
-    public function test_generate_matches_cup()
-    {
-        $this->sql->execute("DELETE FROM matches 
-                    WHERE code_competition IN ('kf', 'cf') 
-                      AND id_journee IN (SELECT id 
-                                         FROM journees 
-                                         WHERE code_competition IN ('kf', 'cf') 
-                                           AND numero = 1)");
-        $cups = array('kf', 'cf');
-        foreach ($cups as $cup_code) {
-            $cup = $this->competition->getCompetition($cup_code);
-            $limit_dates = $this->limit_date->getLimitDates();
-            foreach ($limit_dates as $limit_date) {
-                if ($limit_date['code_competition'] == $cup['code_competition']) {
-                    $this->limit_date->saveLimitDate(
-                        $cup['code_competition'],
-                        date('d/m/Y', strtotime('+2 month')),
-                        $limit_date['id_date']);
-                    break;
-                }
-            }
-            $this->match->delete_matches("code_competition = '$cup_code'");
-            $this->day->deleteDays("code_competition = '$cup_code'");
-            $this->day->insertDay(
-                $cup['code_competition'],
-                strval(1),
-                date('d/m/Y', strtotime('+1 week')),
-                false,
-                $this->limit_date->getLimitDate($cup['code_competition'])
-            );
-            $this->competition->generate_matches_final_phase_cup($cup['id'], 'Journee 01');
-            $sql = "SELECT * 
-                    FROM matches 
-                    WHERE code_competition = '$cup_code' 
-                      AND id_journee IN (SELECT id 
-                                         FROM journees 
-                                         WHERE code_competition = '$cup_code' 
-                                           AND numero = 1)";
-            $this->assertNotEmpty($this->sql->execute($sql));
         }
     }
 

--- a/unit_tests/NewsTest.php
+++ b/unit_tests/NewsTest.php
@@ -11,8 +11,6 @@ class NewsTest extends UfolepTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        @session_start();
-        $_SESSION = [];
     }
 
     protected function tearDown(): void
@@ -23,7 +21,6 @@ class NewsTest extends UfolepTestCase
             $this->sql->execute($sql, $bindings);
             $this->created_news_id = null;
         }
-        $_SESSION = [];
         parent::tearDown();
     }
 

--- a/unit_tests/RankTest.php
+++ b/unit_tests/RankTest.php
@@ -1,59 +1,18 @@
 <?php
 
 require_once __DIR__ . '/../vendor/autoload.php';
-
-use PHPUnit\Framework\TestCase;
+require_once __DIR__ . '/UfolepTestCase.php';
 
 require_once __DIR__ . "/../classes/Rank.php";
 
-class RankTest extends TestCase
+class RankTest extends UfolepTestCase
 {
     private Rank $rank;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->sql_manager = new SqlManager();
         $this->rank = new Rank();
-    }
-
-    /**
-     * @throws Exception
-     */
-    public function test_sort_cup_rank_isoardi()
-    {
-        print_r($this->rank->sort_cup_rank('c'));
-        $this->assertTrue(1 == 1);
-    }
-
-    /**
-     * @throws Exception
-     */
-    public function test_sort_cup_rank_khoury_hanna()
-    {
-        print_r($this->rank->sort_cup_rank('kh'));
-        $this->assertTrue(1 == 1);
-    }
-
-    /**
-     * @throws Exception
-     */
-    public function test_get_rank_by_comp_div()
-    {
-        print_r($this->rank->getRank('c', '14'));
-        $this->assertTrue(1 == 1);
-    }
-
-    /**
-     * @throws Exception
-     */
-    public function test_get()
-    {
-        $result = $this->rank->getLeader('ut', '1');
-        print_r($result);
-        $result = $this->rank->getViceLeader('ut', '1');
-        print_r($result);
-        $this->assertTrue(1 == 1);
     }
 
     /**

--- a/unit_tests/RegisterTest.php
+++ b/unit_tests/RegisterTest.php
@@ -33,86 +33,23 @@ class RegisterTest extends UfolepTestCase
         $this->register = new Register();
     }
 
-
     /**
      * @throws Exception
      */
-    public function test_set_up_season_kh()
+    protected function tearDown(): void
     {
-        //230105:PASS
         $competition_mgr = new Competition();
-        $competition_kh = $competition_mgr->getCompetition('kh');
-        $this->register->set_up_season($competition_kh['id']);
-        $this->assertTrue(1 == 1);
-    }
-
-    /**
-     * @throws Exception
-     */
-    public function test_set_up_season_isoardi()
-    {
-        //230105:PASS
-        $competition_mgr = new Competition();
-        // initial conditions:
-        // - remove all 'm' teams from classements
-        $this->sql->execute("DELETE FROM classements WHERE code_competition ='m'");
-        // - pick 10 teams from 'm' with is_cup_registered = 1, and add them to classements
-        // - 5 teams in division 1 with rank_start 1-5, and 5 teams in division 2 with rank_start 1-5
-        $sql = "INSERT INTO classements(code_competition, division, id_equipe, rank_start) 
-                SELECT 'm', 
-                       CASE WHEN row_num <= 5 THEN '1' ELSE '2' END as division, 
-                       id_equipe, 
-                       CASE WHEN row_num <= 5 THEN row_num ELSE row_num - 5 END as rank_start
-                FROM (
-                    SELECT id_equipe, @row_number := @row_number + 1 as row_num
-                    FROM equipes, (SELECT @row_number := 0) as r
-                    WHERE code_competition = 'm' AND is_cup_registered = 1
-                    LIMIT 10
-                ) as numbered_teams";
-        $this->sql->execute($sql);
-        // test for isoardi, where registration is automatic
-        $competition_isoardi = $competition_mgr->getCompetition('c');
-        $this->register->set_up_season($competition_isoardi['id']);
-        $this->assertTrue(1 == 1);
-    }
-
-    /**
-     * @throws Exception
-     */
-    public function test_set_up_season_masc()
-    {
-        //230219:PASS
-        $competition_mgr = new Competition();
-        // test for masc
-        $competition_masc = $competition_mgr->getCompetition('m');
-        $this->register->set_up_season($competition_masc['id']);
-        $this->assertTrue(1 == 1);
-    }
-
-    /**
-     * @throws Exception
-     */
-    public function test_set_up_season_fem()
-    {
-        //230219:PASS
-        $competition_mgr = new Competition();
-        // test for masc
-        $competition_masc = $competition_mgr->getCompetition('f');
-        $this->register->set_up_season($competition_masc['id']);
-        $this->assertTrue(1 == 1);
-    }
-
-    /**
-     * @throws Exception
-     */
-    public function test_set_up_season_mo()
-    {
-        //230219:PASS
-        $competition_mgr = new Competition();
-        // test for masc
-        $competition = $competition_mgr->getCompetition('mo');
-        $this->register->set_up_season($competition['id']);
-        $this->assertTrue(1 == 1);
+        foreach (array('f', 'm', 'mo') as $code_competition) {
+            $comp = $competition_mgr->getCompetition($code_competition);
+            if ($comp) {
+                $registrations = $this->register->get("id_competition = ? AND nom_equipe LIKE 'test_%'", array(array('type' => 'i', 'value' => $comp['id'])));
+                $ids = array_column($registrations, 'id');
+                if (count($ids) > 0) {
+                    $this->register->delete(implode(',', $ids));
+                }
+            }
+        }
+        parent::tearDown();
     }
 
     /**
@@ -120,13 +57,11 @@ class RegisterTest extends UfolepTestCase
      */
     public function test_get_pending_registrations()
     {
-        //230123:PASS
         $competition_mgr = new Competition();
-        $comp = $competition_mgr->getCompetition('ut');
-        $this->delete_registrations_from_competition($comp['id']);
+        $comp = $competition_mgr->getCompetition('m');
         try {
             $this->register->register(
-                'test_ut',
+                'test_m_pending_' . time(),
                 41, // club de test
                 $comp['id'],
                 null,

--- a/unit_tests/UfolepTestCase.php
+++ b/unit_tests/UfolepTestCase.php
@@ -30,4 +30,10 @@ class UfolepTestCase extends TestCase
         $_SESSION['id_user'] = 1;
         $_SESSION['profile_name'] = 'RESPONSABLE_EQUIPE';
     }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+        parent::tearDown();
+    }
 }


### PR DESCRIPTION
## Résumé

Refactoring des tests unitaires PHP pour les rendre **non-destructifs** et supprimer les tests obsolètes de génération de matchs (migrés vers le repo Python).

Closes #202

## Changements

### UfolepTestCase (base class)
- Ajout d'un `tearDown()` qui reset `$_SESSION` après chaque test

### Tests supprimés (obsolètes / destructifs)

| Fichier | Tests supprimés | Raison |
|---------|----------------|--------|
| **MatchManagerTest** | `test_generate_days`, `test_generate_matches`, `test_generate_matches_v2`, `test_generate_all_kh`, `test_generate_all_isoardi`, `test_generate_all_m`, `test_generate_with_params`, `test_generate_all_championships`, `test_adjust_home_away`, `test_draw_matches`, `test_getMatchPlayers`, `test_get` | Génération de matchs migrée vers Python + tests debug sans assertions |
| **CompetitionTest** | `testInit_classements_isoardi`, `test_is_first_half`, `test_generate_matches_cup` | Modifient des données de prod (classements, start_date, matchs de coupe) |
| **RegisterTest** | `test_set_up_season_kh`, `test_set_up_season_isoardi`, `test_set_up_season_masc`, `test_set_up_season_fem`, `test_set_up_season_mo` | Modifient des données de prod (setup saison) |
| **EmailsTest** | `testSend_pending_emails`, `test_send_some_mails` | Envoient de vrais emails + `delete_emails()` supprime TOUS les emails |
| **PlayersTest** | `test_generateLowPhoto`, `test_getPlayersPdf`, `test_import_all_licences_from_test_directory` | Écrivent sur disque / aucun nettoyage |
| **RankTest** | `test_sort_cup_rank_*`, `test_get_rank_by_comp_div`, `test_get` | Tests debug (print_r + assertTrue(1==1)) |

### Tests rendus non-destructifs (setUp/tearDown)

- **MatchManagerTest** : ajout `tearDown()` avec nettoyage complet (compétition 'ut', blacklists, comptes), suppression du cleanup inline
- **CourtTest** : cleanup gymnases déplacé en `tearDown()`
- **LiveScoreTest** : cleanup live scores déplacé en `tearDown()`
- **EmailsTest** : tracking des IDs créés pour cleanup en `tearDown()`
- **TeamTest** : restauration des remarques gymnase en `tearDown()`
- **RegisterTest** : nettoyage des inscriptions test en `tearDown()`, utilisation de compétitions réelles au lieu de dépendance cross-test sur 'ut'
- **NewsTest/ActAsTest** : suppression du reset session dupliqué (géré par la classe de base)

## Résultats

```
Tests: 68, Assertions: 2510, Skipped: 1
OK (0 errors, 0 failures)
```

Bilan : **+126 / -720 lignes**
