### PR TITLE
Feature #201: Survey notation 0-5 vers 0-10 (10 étoiles)

### DIFF
--- a/classes/MatchMgr.php
+++ b/classes/MatchMgr.php
@@ -2093,6 +2093,12 @@ class MatchMgr extends Generic
                                 $dirtyFields = null,
                                 $id = null): int|array|string|null
     {
+        $ratings = ['on_time' => $on_time, 'spirit' => $spirit, 'referee' => $referee, 'catering' => $catering, 'global' => $global];
+        foreach ($ratings as $field => $value) {
+            if ($value < 0 || $value > 10) {
+                throw new InvalidArgumentException("La note '$field' doit être comprise entre 0 et 10 (reçu: $value)");
+            }
+        }
         $userDetails = $this->getCurrentUserDetails();
         $id_user = $userDetails['id_user'];
         $inputs = array(

--- a/match.php
+++ b/match.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 require_once __DIR__ . '/classes/Generic.php';
 require_once __DIR__ . '/classes/MatchMgr.php';
 try {

--- a/survey.php
+++ b/survey.php
@@ -70,6 +70,11 @@ $user_details = $_SESSION;
                     <input type="radio" v-model="surveyData.on_time" :value="3" class="mask mask-star"/>
                     <input type="radio" v-model="surveyData.on_time" :value="4" class="mask mask-star"/>
                     <input type="radio" v-model="surveyData.on_time" :value="5" class="mask mask-star"/>
+                    <input type="radio" v-model="surveyData.on_time" :value="6" class="mask mask-star"/>
+                    <input type="radio" v-model="surveyData.on_time" :value="7" class="mask mask-star"/>
+                    <input type="radio" v-model="surveyData.on_time" :value="8" class="mask mask-star"/>
+                    <input type="radio" v-model="surveyData.on_time" :value="9" class="mask mask-star"/>
+                    <input type="radio" v-model="surveyData.on_time" :value="10" class="mask mask-star"/>
                 </div>
             </div>
             <div class="rating flex">
@@ -81,6 +86,11 @@ $user_details = $_SESSION;
                     <input type="radio" v-model="surveyData.spirit" :value="3" class="mask mask-star"/>
                     <input type="radio" v-model="surveyData.spirit" :value="4" class="mask mask-star"/>
                     <input type="radio" v-model="surveyData.spirit" :value="5" class="mask mask-star"/>
+                    <input type="radio" v-model="surveyData.spirit" :value="6" class="mask mask-star"/>
+                    <input type="radio" v-model="surveyData.spirit" :value="7" class="mask mask-star"/>
+                    <input type="radio" v-model="surveyData.spirit" :value="8" class="mask mask-star"/>
+                    <input type="radio" v-model="surveyData.spirit" :value="9" class="mask mask-star"/>
+                    <input type="radio" v-model="surveyData.spirit" :value="10" class="mask mask-star"/>
                 </div>
             </div>
             <div class="rating flex">
@@ -92,6 +102,11 @@ $user_details = $_SESSION;
                     <input type="radio" v-model="surveyData.referee" :value="3" class="mask mask-star"/>
                     <input type="radio" v-model="surveyData.referee" :value="4" class="mask mask-star"/>
                     <input type="radio" v-model="surveyData.referee" :value="5" class="mask mask-star"/>
+                    <input type="radio" v-model="surveyData.referee" :value="6" class="mask mask-star"/>
+                    <input type="radio" v-model="surveyData.referee" :value="7" class="mask mask-star"/>
+                    <input type="radio" v-model="surveyData.referee" :value="8" class="mask mask-star"/>
+                    <input type="radio" v-model="surveyData.referee" :value="9" class="mask mask-star"/>
+                    <input type="radio" v-model="surveyData.referee" :value="10" class="mask mask-star"/>
                 </div>
             </div>
             <div class="rating flex">
@@ -103,6 +118,11 @@ $user_details = $_SESSION;
                     <input type="radio" v-model="surveyData.catering" :value="3" class="mask mask-star"/>
                     <input type="radio" v-model="surveyData.catering" :value="4" class="mask mask-star"/>
                     <input type="radio" v-model="surveyData.catering" :value="5" class="mask mask-star"/>
+                    <input type="radio" v-model="surveyData.catering" :value="6" class="mask mask-star"/>
+                    <input type="radio" v-model="surveyData.catering" :value="7" class="mask mask-star"/>
+                    <input type="radio" v-model="surveyData.catering" :value="8" class="mask mask-star"/>
+                    <input type="radio" v-model="surveyData.catering" :value="9" class="mask mask-star"/>
+                    <input type="radio" v-model="surveyData.catering" :value="10" class="mask mask-star"/>
                 </div>
             </div>
             <div class="rating flex">
@@ -114,6 +134,11 @@ $user_details = $_SESSION;
                     <input type="radio" v-model="surveyData.global" :value="3" class="mask mask-star"/>
                     <input type="radio" v-model="surveyData.global" :value="4" class="mask mask-star"/>
                     <input type="radio" v-model="surveyData.global" :value="5" class="mask mask-star"/>
+                    <input type="radio" v-model="surveyData.global" :value="6" class="mask mask-star"/>
+                    <input type="radio" v-model="surveyData.global" :value="7" class="mask mask-star"/>
+                    <input type="radio" v-model="surveyData.global" :value="8" class="mask mask-star"/>
+                    <input type="radio" v-model="surveyData.global" :value="9" class="mask mask-star"/>
+                    <input type="radio" v-model="surveyData.global" :value="10" class="mask mask-star"/>
                 </div>
             </div>
         </div>

--- a/unit_tests/SurveyTest.php
+++ b/unit_tests/SurveyTest.php
@@ -1,0 +1,185 @@
+<?php
+require_once __DIR__ . '/../classes/MatchMgr.php';
+require_once __DIR__ . '/../classes/SqlManager.php';
+require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/UfolepTestCase.php';
+
+class SurveyTest extends UfolepTestCase
+{
+    private MatchMgr $match_manager;
+    private int $test_user_id;
+    private int $test_match_id;
+
+    private function create_test_data(): void
+    {
+        $this->delete_test_data();
+        $this->test_user_id = $this->sql->execute(
+            "INSERT INTO comptes_acces SET login = 'survey_test_user', email = 'survey_test@test.fr', password_hash = MD5('test')");
+        $this->sql->execute(
+            "INSERT INTO users_profiles SET user_id = ?, profile_id = (SELECT id FROM profiles WHERE name = 'ADMINISTRATEUR')",
+            array(array('type' => 'i', 'value' => $this->test_user_id)));
+        $id_club = $this->sql->execute("INSERT INTO clubs SET nom = 'survey test club 1'");
+        $id_club2 = $this->sql->execute("INSERT INTO clubs SET nom = 'survey test club 2'");
+        $id_team1 = $this->sql->execute(
+            "INSERT INTO equipes SET code_competition = 'ut', nom_equipe = 'survey test team 1', id_club = $id_club");
+        $id_team2 = $this->sql->execute(
+            "INSERT INTO equipes SET code_competition = 'ut', nom_equipe = 'survey test team 2', id_club = $id_club2");
+        $this->sql->execute(
+            "INSERT INTO users_teams SET user_id = ?, team_id = ?",
+            array(
+                array('type' => 'i', 'value' => $this->test_user_id),
+                array('type' => 'i', 'value' => $id_team1),
+            ));
+        $id_day = $this->sql->execute(
+            "INSERT INTO journees SET code_competition = 'ut', numero = 99, nommage = 'SURVEY_TEST', libelle = 'Survey Test', start_date = CURRENT_DATE");
+        $id_court = $this->sql->execute("INSERT INTO gymnase SET nom = 'survey test court'");
+        $this->test_match_id = $this->sql->execute(
+            "INSERT INTO matches SET
+                code_match = 'SURVEY_UT001',
+                code_competition = 'ut',
+                division = '1',
+                id_equipe_dom = $id_team1,
+                id_equipe_ext = $id_team2,
+                date_reception = CURRENT_DATE,
+                id_journee = $id_day,
+                id_gymnasium = $id_court,
+                date_original = CURRENT_DATE,
+                match_status = 'CONFIRMED'");
+    }
+
+    private function delete_test_data(): void
+    {
+        $this->sql->execute("DELETE FROM survey WHERE id_match IN (SELECT id FROM matches WHERE code_match = 'SURVEY_UT001')");
+        $this->sql->execute("DELETE FROM matches WHERE code_match = 'SURVEY_UT001'");
+        $this->sql->execute("DELETE FROM journees WHERE nommage = 'SURVEY_TEST'");
+        $this->sql->execute("DELETE FROM users_teams WHERE user_id IN (SELECT id FROM comptes_acces WHERE login = 'survey_test_user')");
+        $this->sql->execute("DELETE FROM users_profiles WHERE user_id IN (SELECT id FROM comptes_acces WHERE login = 'survey_test_user')");
+        $this->sql->execute("DELETE FROM comptes_acces WHERE login = 'survey_test_user'");
+        $this->sql->execute("DELETE FROM equipes WHERE nom_equipe LIKE 'survey test team %'");
+        $this->sql->execute("DELETE FROM clubs WHERE nom LIKE 'survey test club %'");
+        $this->sql->execute("DELETE FROM creneau WHERE id_gymnase IN (SELECT id FROM gymnase WHERE nom = 'survey test court')");
+        $this->sql->execute("DELETE FROM gymnase WHERE nom = 'survey test court'");
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->match_manager = new MatchMgr();
+        $this->create_test_data();
+        @session_start();
+        $_SESSION['id_equipe'] = null;
+        $_SESSION['login'] = 'survey_test_user';
+        $_SESSION['id_user'] = $this->test_user_id;
+        $_SESSION['profile_name'] = 'ADMINISTRATEUR';
+    }
+
+    public function test_save_survey_rejects_on_time_above_10()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->match_manager->save_survey(
+            id_match: $this->test_match_id,
+            on_time: 11,
+            spirit: 5,
+            referee: 5,
+            catering: 5,
+            global: 5
+        );
+    }
+
+    public function test_save_survey_rejects_negative_on_time()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->match_manager->save_survey(
+            id_match: $this->test_match_id,
+            on_time: -1,
+            spirit: 5,
+            referee: 5,
+            catering: 5,
+            global: 5
+        );
+    }
+
+    public function test_save_survey_rejects_spirit_above_10()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->match_manager->save_survey(
+            id_match: $this->test_match_id,
+            on_time: 5,
+            spirit: 15,
+            referee: 5,
+            catering: 5,
+            global: 5
+        );
+    }
+
+    public function test_save_survey_rejects_referee_above_10()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->match_manager->save_survey(
+            id_match: $this->test_match_id,
+            on_time: 5,
+            spirit: 5,
+            referee: 12,
+            catering: 5,
+            global: 5
+        );
+    }
+
+    public function test_save_survey_rejects_catering_above_10()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->match_manager->save_survey(
+            id_match: $this->test_match_id,
+            on_time: 5,
+            spirit: 5,
+            referee: 5,
+            catering: 11,
+            global: 5
+        );
+    }
+
+    public function test_save_survey_rejects_global_above_10()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->match_manager->save_survey(
+            id_match: $this->test_match_id,
+            on_time: 5,
+            spirit: 5,
+            referee: 5,
+            catering: 5,
+            global: 11
+        );
+    }
+
+    public function test_save_survey_accepts_value_10()
+    {
+        $result = $this->match_manager->save_survey(
+            id_match: $this->test_match_id,
+            on_time: 10,
+            spirit: 10,
+            referee: 10,
+            catering: 10,
+            global: 10
+        );
+        $this->assertNotNull($result);
+    }
+
+    public function test_save_survey_accepts_value_0()
+    {
+        $result = $this->match_manager->save_survey(
+            id_match: $this->test_match_id,
+            on_time: 0,
+            spirit: 0,
+            referee: 0,
+            catering: 0,
+            global: 0
+        );
+        $this->assertNotNull($result);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->delete_test_data();
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
## Description
Résout #201

Passe la notation des surveys de l'échelle 0-5 à 0-10 (10 étoiles).

## Changements
- **UI (`survey.php`)** : affiche 10 étoiles par critère (on_time, spirit, referee, catering, global)
- **Backend (`classes/MatchMgr.php`)** : validation des notes entre 0 et 10 dans `save_survey()` avec `InvalidArgumentException`
- **Tests (`unit_tests/SurveyTest.php`)** : 8 tests avec jeu de données dédié (création/suppression en setUp/tearDown)
- **SQL migration** : `005-survey_rating_scale_5_to_10.sql` dans ufolep13volley_python (déjà pushé sur master) — multiplie par 2 les notes existantes
- **Fix bonus** : suppression BOM UTF-8 dans `match.php`

## Tests
- [x] Tests unitaires ajoutés (SurveyTest - 8 tests)
- [x] Tous les tests passent (76 tests, 2518 assertions)

## Checklist
- [ ] Code review demandée
- [ ] Exécuter le script SQL de migration en production
