### PR TITLE
Feature #218: Réorganiser la dropdown Coupes en 4 sections

### DIFF
--- a/e2e/tests/issue_218.spec.js
+++ b/e2e/tests/issue_218.spec.js
@@ -2,51 +2,89 @@
 const { test, expect } = require('@playwright/test');
 
 /**
- * E2E — Dropdown Coupes réorganisée en 4 sections (issue #218)
+ * E2E — Dropdown Coupes réorganisée en 4 sous-menus collapsibles (issue #218)
  *
  * Scénario :
  *  1. Ouvrir la page d'accueil
  *  2. Cliquer sur le bouton "Coupes" dans la navbar
- *  3. Vérifier la présence des 4 sections : Tirages, Poules, Qualifiés, Phases finales
- *  4. Prendre un screenshot de preuve
+ *  3. Vérifier la présence des 4 sous-menus (Tirages, Poules, Qualifiés, Phases finales)
+ *  4. Vérifier que les sous-menus sont fermés par défaut
+ *  5. Ouvrir chaque sous-menu et vérifier son contenu
+ *  6. Vérifier que les poules sont affichées en grille de numéros compacts
  */
 
-test.describe('Issue #218 — Dropdown Coupes en 4 sections', () => {
-    test('la dropdown Coupes affiche les 4 sections attendues', async ({ page }) => {
+test.describe('Issue #218 — Dropdown Coupes en 4 sous-menus collapsibles', () => {
+    test('les 4 sous-menus sont présents et fermés par défaut', async ({ page }) => {
         await page.goto('/');
 
-        // Ouvrir la dropdown Coupes
         const coupesBtn = page.locator('.navbar .dropdown').filter({ hasText: 'Coupes' }).first();
         await coupesBtn.locator('[role="button"]').click();
 
         const dropdown = coupesBtn.locator('.dropdown-content');
 
-        // Vérifier les 4 titres de section
-        await expect(dropdown.locator('.menu-title', { hasText: 'Tirages' })).toBeVisible();
-        await expect(dropdown.locator('.menu-title', { hasText: 'Poules' })).toBeVisible();
-        await expect(dropdown.locator('.menu-title', { hasText: 'Qualifiés' })).toBeVisible();
-        await expect(dropdown.locator('.menu-title', { hasText: 'Phases finales' })).toBeVisible();
+        // Les 4 summary doivent être visibles
+        await expect(dropdown.locator('summary', { hasText: 'Tirages' })).toBeVisible();
+        await expect(dropdown.locator('summary', { hasText: 'Poules' })).toBeVisible();
+        await expect(dropdown.locator('summary', { hasText: 'Qualifiés' })).toBeVisible();
+        await expect(dropdown.locator('summary', { hasText: 'Phases finales' })).toBeVisible();
+
+        // Les <details> ne doivent pas avoir l'attribut open par défaut
+        const details = dropdown.locator('details');
+        const count = await details.count();
+        for (let i = 0; i < count; i++) {
+            await expect(details.nth(i)).not.toHaveAttribute('open');
+        }
 
         await page.screenshot({
-            path: 'test-results/issue-218/dropdown_coupes_4_sections.png',
+            path: 'test-results/issue-218/dropdown_collapsed.png',
             fullPage: false,
         });
     });
 
-    test('la section Tirages contient les liens vers les tirages des deux coupes', async ({ page }) => {
+    test('le sous-menu Tirages contient les liens vers les deux coupes', async ({ page }) => {
         await page.goto('/');
 
         const coupesBtn = page.locator('.navbar .dropdown').filter({ hasText: 'Coupes' }).first();
         await coupesBtn.locator('[role="button"]').click();
 
         const dropdown = coupesBtn.locator('.dropdown-content');
+        const tiragesDetails = dropdown.locator('details').filter({
+            has: page.locator('summary', { hasText: 'Tirages' }),
+        });
+        await tiragesDetails.locator('summary').click();
 
-        // Les liens de tirage doivent être présents
-        await expect(dropdown.locator('a, [href]', { hasText: /tirage.*Isoardi/i })).toBeVisible();
-        await expect(dropdown.locator('a, [href]', { hasText: /tirage.*Khoury/i })).toBeVisible();
+        await expect(tiragesDetails.locator('a', { hasText: 'Coupe Isoardi' })).toBeVisible();
+        await expect(tiragesDetails.locator('a', { hasText: 'Coupe Khoury Hanna' })).toBeVisible();
 
         await page.screenshot({
-            path: 'test-results/issue-218/section_tirages.png',
+            path: 'test-results/issue-218/submenu_tirages.png',
+            fullPage: false,
+        });
+    });
+
+    test('le sous-menu Poules affiche des numéros compacts en grille', async ({ page }) => {
+        await page.goto('/');
+
+        const coupesBtn = page.locator('.navbar .dropdown').filter({ hasText: 'Coupes' }).first();
+        await coupesBtn.locator('[role="button"]').click();
+
+        const dropdown = coupesBtn.locator('.dropdown-content');
+        await dropdown.locator('summary', { hasText: 'Poules' }).click();
+
+        // La grille doit contenir des boutons avec des numéros courts (pas de texte long)
+        const grid = dropdown.locator('.flex.flex-wrap');
+        await expect(grid.first()).toBeVisible();
+
+        const buttons = grid.first().locator('.btn-xs');
+        const btnCount = await buttons.count();
+        expect(btnCount).toBeGreaterThan(0);
+
+        // Vérifier que le texte est court (numéro seul, pas "Coupe Isoardi — poule 1")
+        const firstBtnText = await buttons.first().textContent();
+        expect(firstBtnText?.trim().length).toBeLessThan(5);
+
+        await page.screenshot({
+            path: 'test-results/issue-218/submenu_poules_grid.png',
             fullPage: false,
         });
     });

--- a/e2e/tests/issue_218.spec.js
+++ b/e2e/tests/issue_218.spec.js
@@ -1,0 +1,53 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+/**
+ * E2E — Dropdown Coupes réorganisée en 4 sections (issue #218)
+ *
+ * Scénario :
+ *  1. Ouvrir la page d'accueil
+ *  2. Cliquer sur le bouton "Coupes" dans la navbar
+ *  3. Vérifier la présence des 4 sections : Tirages, Poules, Qualifiés, Phases finales
+ *  4. Prendre un screenshot de preuve
+ */
+
+test.describe('Issue #218 — Dropdown Coupes en 4 sections', () => {
+    test('la dropdown Coupes affiche les 4 sections attendues', async ({ page }) => {
+        await page.goto('/');
+
+        // Ouvrir la dropdown Coupes
+        const coupesBtn = page.locator('.navbar .dropdown').filter({ hasText: 'Coupes' }).first();
+        await coupesBtn.locator('[role="button"]').click();
+
+        const dropdown = coupesBtn.locator('.dropdown-content');
+
+        // Vérifier les 4 titres de section
+        await expect(dropdown.locator('.menu-title', { hasText: 'Tirages' })).toBeVisible();
+        await expect(dropdown.locator('.menu-title', { hasText: 'Poules' })).toBeVisible();
+        await expect(dropdown.locator('.menu-title', { hasText: 'Qualifiés' })).toBeVisible();
+        await expect(dropdown.locator('.menu-title', { hasText: 'Phases finales' })).toBeVisible();
+
+        await page.screenshot({
+            path: 'test-results/issue-218/dropdown_coupes_4_sections.png',
+            fullPage: false,
+        });
+    });
+
+    test('la section Tirages contient les liens vers les tirages des deux coupes', async ({ page }) => {
+        await page.goto('/');
+
+        const coupesBtn = page.locator('.navbar .dropdown').filter({ hasText: 'Coupes' }).first();
+        await coupesBtn.locator('[role="button"]').click();
+
+        const dropdown = coupesBtn.locator('.dropdown-content');
+
+        // Les liens de tirage doivent être présents
+        await expect(dropdown.locator('a, [href]', { hasText: /tirage.*Isoardi/i })).toBeVisible();
+        await expect(dropdown.locator('a, [href]', { hasText: /tirage.*Khoury/i })).toBeVisible();
+
+        await page.screenshot({
+            path: 'test-results/issue-218/section_tirages.png',
+            fullPage: false,
+        });
+    });
+});

--- a/pages/components/navbar/Main.js
+++ b/pages/components/navbar/Main.js
@@ -29,34 +29,39 @@ export default {
             <div tabindex="0" role="button" class="btn btn-ghost">
               <span><i class="fas fa-calendar mr-2"/>Coupes<i class="ml-1 fas fa-chevron-down"/></span>
             </div>
-            <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-50 mt-3 w-52 p-2 shadow">
-              <li class="menu-title">Coupe Isoardi</li>
+            <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-50 mt-3 w-56 p-2 shadow">
+              <li class="menu-title">Tirages</li>
               <li>
                 <router-link to="/cup-draw/m">
                   <i class="fas fa-random mr-1"/>tirage coupe Isoardi
                 </router-link>
               </li>
-              <li class="menu-title">Coupe Khoury Hanna</li>
               <li>
                 <router-link to="/cup-draw-kh">
                   <i class="fas fa-random mr-1"/>tirage coupe Khoury Hanna
                 </router-link>
               </li>
+              <li class="menu-title">Poules</li>
               <template v-for="group in groupedPools">
-                <li class="menu-title">{{ group.libelle }}</li>
-                <li>
-                  <router-link :to="'/finals/'+group.code_competition_finals">
-                    phases finales
-                  </router-link>
-                </li>
-                <li>
-                  <a target="_blank" :href="'/rank_for_cup.php?code_competition='+group.code_competition">
-                    classement général
-                  </a>
-                </li>
                 <li v-for="division in group.divisions" :key="division.code_competition+division.division">
                   <router-link :to="'/divisions/'+division.code_competition+'/'+ division.division">
-                    poule {{ division.division }}
+                    {{ group.libelle }} — poule {{ division.division }}
+                  </router-link>
+                </li>
+              </template>
+              <li class="menu-title">Qualifiés</li>
+              <template v-for="group in groupedPools">
+                <li>
+                  <a target="_blank" :href="'/rank_for_cup.php?code_competition='+group.code_competition">
+                    <i class="fas fa-list-ol mr-1"/>{{ group.libelle }}
+                  </a>
+                </li>
+              </template>
+              <li class="menu-title">Phases finales</li>
+              <template v-for="group in groupedPools">
+                <li>
+                  <router-link :to="'/finals/'+group.code_competition_finals">
+                    <i class="fas fa-trophy mr-1"/>{{ group.libelle }}
                   </router-link>
                 </li>
               </template>

--- a/pages/components/navbar/Main.js
+++ b/pages/components/navbar/Main.js
@@ -30,41 +30,68 @@ export default {
               <span><i class="fas fa-calendar mr-2"/>Coupes<i class="ml-1 fas fa-chevron-down"/></span>
             </div>
             <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-50 mt-3 w-56 p-2 shadow">
-              <li class="menu-title">Tirages</li>
               <li>
-                <router-link to="/cup-draw/m">
-                  <i class="fas fa-random mr-1"/>tirage coupe Isoardi
-                </router-link>
+                <details>
+                  <summary><i class="fas fa-random mr-2"/>Tirages</summary>
+                  <ul>
+                    <li>
+                      <router-link to="/cup-draw/m">Coupe Isoardi</router-link>
+                    </li>
+                    <li>
+                      <router-link to="/cup-draw-kh">Coupe Khoury Hanna</router-link>
+                    </li>
+                  </ul>
+                </details>
               </li>
               <li>
-                <router-link to="/cup-draw-kh">
-                  <i class="fas fa-random mr-1"/>tirage coupe Khoury Hanna
-                </router-link>
+                <details>
+                  <summary><i class="fas fa-th mr-2"/>Poules</summary>
+                  <ul>
+                    <template v-for="group in groupedPools">
+                      <li class="menu-title">{{ group.libelle }}</li>
+                      <li>
+                        <div class="flex flex-wrap gap-1 p-1">
+                          <router-link
+                            v-for="division in group.divisions"
+                            :key="division.code_competition+division.division"
+                            :to="'/divisions/'+division.code_competition+'/'+division.division"
+                            class="btn btn-xs btn-outline">
+                            {{ division.division }}
+                          </router-link>
+                        </div>
+                      </li>
+                    </template>
+                  </ul>
+                </details>
               </li>
-              <li class="menu-title">Poules</li>
-              <template v-for="group in groupedPools">
-                <li v-for="division in group.divisions" :key="division.code_competition+division.division">
-                  <router-link :to="'/divisions/'+division.code_competition+'/'+ division.division">
-                    {{ group.libelle }} — poule {{ division.division }}
-                  </router-link>
-                </li>
-              </template>
-              <li class="menu-title">Qualifiés</li>
-              <template v-for="group in groupedPools">
-                <li>
-                  <a target="_blank" :href="'/rank_for_cup.php?code_competition='+group.code_competition">
-                    <i class="fas fa-list-ol mr-1"/>{{ group.libelle }}
-                  </a>
-                </li>
-              </template>
-              <li class="menu-title">Phases finales</li>
-              <template v-for="group in groupedPools">
-                <li>
-                  <router-link :to="'/finals/'+group.code_competition_finals">
-                    <i class="fas fa-trophy mr-1"/>{{ group.libelle }}
-                  </router-link>
-                </li>
-              </template>
+              <li>
+                <details>
+                  <summary><i class="fas fa-list-ol mr-2"/>Qualifiés</summary>
+                  <ul>
+                    <template v-for="group in groupedPools">
+                      <li>
+                        <a target="_blank" :href="'/rank_for_cup.php?code_competition='+group.code_competition">
+                          {{ group.libelle }}
+                        </a>
+                      </li>
+                    </template>
+                  </ul>
+                </details>
+              </li>
+              <li>
+                <details>
+                  <summary><i class="fas fa-trophy mr-2"/>Phases finales</summary>
+                  <ul>
+                    <template v-for="group in groupedPools">
+                      <li>
+                        <router-link :to="'/finals/'+group.code_competition_finals">
+                          {{ group.libelle }}
+                        </router-link>
+                      </li>
+                    </template>
+                  </ul>
+                </details>
+              </li>
             </ul>
           </div>
           <div class="dropdown">


### PR DESCRIPTION
## Description
Résout #218

## Changements
- Dropdown "Coupes" restructurée en 4 sections distinctes : **Tirages**, **Poules**, **Qualifiés**, **Phases finales**
- Tirages (Isoardi + Khoury Hanna) regroupés en tête
- Poules affichées avec le nom de la compétition pour plus de clarté
- Qualifiés = classements généraux (anciennement éparpillés)
- Phases finales = liens vers les phases finales par compétition
- Ajout d'icônes sur Qualifiés (`fa-list-ol`) et Phases finales (`fa-trophy`)
- Légère augmentation de la largeur (w-52 → w-56) pour accommoder les libellés

## Tests
- [x] Test E2E Playwright ajouté (`e2e/tests/issue_218.spec.js`)
- [x] Screenshots de preuve dans `e2e/test-results/issue-218/`
- [x] 2/2 tests passent

## Checklist
- [x] Code review demandée
- [ ] Documentation mise à jour si nécessaire
