### PR TITLE
feat(#221): consultation et suivi de lecture des emails par les responsables d'équipe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ test.afterAll(async ({ request }) => {
 - `test_setup.php` / `test_teardown.php` — match live score (issue #217)
 - `test_verify.php` — vérifie les scores en base après `save_to_match`
 - `finals_setup.php` / `finals_teardown.php` — matchs 1/8 finale KF/CF (issue #215)
+- `messages_setup.php` / `messages_teardown.php` — emails non lus pour responsable d'équipe (issue #221)
 
 ### Installer les dépendances PHP
 ```bash

--- a/classes/Emails.php
+++ b/classes/Emails.php
@@ -1011,9 +1011,123 @@ class Emails extends Generic
                     body,
                     DATE_FORMAT(creation_date, '%d/%m/%Y %H:%i:%s') AS creation_date,
                     DATE_FORMAT(sent_date, '%d/%m/%Y %H:%i:%s') AS sent_date,
-                    sending_status
+                    sending_status,
+                    is_read
                 FROM emails
                 WHERE $query
                 ORDER BY id DESC";
+    }
+
+    /**
+     * Retourne les emails destinés à une équipe (to, cc, bcc matchent une adresse liée à l'équipe).
+     * Accessible uniquement à l'admin ou au responsable de l'équipe en session.
+     * @param int $id_equipe
+     * @return array
+     * @throws Exception
+     */
+    public function get_team_emails(int $id_equipe): array
+    {
+        if (!UserManager::isAdmin() && !UserManager::isTeamLeader()) {
+            throw new Exception("Accès non autorisé !", 401);
+        }
+        if (UserManager::isTeamLeader()) {
+            $session_team = (int)$_SESSION['id_equipe'];
+            if ($session_team !== $id_equipe) {
+                throw new Exception("Vous n'êtes pas autorisé à consulter les messages de cette équipe !", 401);
+            }
+        }
+        $sql = "SELECT DISTINCT j.email
+                FROM joueurs j
+                JOIN joueur_equipe je ON je.id_joueur = j.id
+                WHERE je.id_equipe = ?
+                  AND j.email IS NOT NULL
+                  AND j.email != ''";
+        $bindings = array(
+            array('type' => 'i', 'value' => $id_equipe),
+        );
+        $rows = $this->sql_manager->execute($sql, $bindings);
+        if (empty($rows)) {
+            return array();
+        }
+        $addresses = array_map(fn($r) => $r['email'], $rows);
+        $placeholders = implode(',', array_fill(0, count($addresses), '?'));
+        $addr_bindings = array_map(fn($a) => array('type' => 's', 'value' => $a), $addresses);
+        $addr_bindings_2 = $addr_bindings;
+        $addr_bindings_3 = $addr_bindings;
+        $email_sql = "SELECT
+                    id,
+                    to_email,
+                    cc,
+                    bcc,
+                    subject,
+                    LEFT(body, 200) AS body_preview,
+                    body,
+                    DATE_FORMAT(creation_date, '%d/%m/%Y %H:%i:%s') AS creation_date_fmt,
+                    DATE_FORMAT(sent_date, '%d/%m/%Y %H:%i:%s') AS sent_date_fmt,
+                    sending_status,
+                    is_read
+                FROM emails
+                WHERE (to_email IN ($placeholders)
+                    OR cc IN ($placeholders)
+                    OR bcc IN ($placeholders))
+                ORDER BY creation_date DESC, id DESC";
+        return $this->sql_manager->execute($email_sql, array_merge($addr_bindings, $addr_bindings_2, $addr_bindings_3));
+    }
+
+    /**
+     * Met à jour le statut de lecture d'un email.
+     * Accessible uniquement à l'admin ou au responsable d'une équipe qui a reçu cet email.
+     * @param int $id
+     * @param int $is_read
+     * @throws Exception
+     */
+    public function set_read_status(int $id, int $is_read): void
+    {
+        if (!UserManager::isAdmin() && !UserManager::isTeamLeader()) {
+            throw new Exception("Accès non autorisé !", 401);
+        }
+        if (UserManager::isTeamLeader()) {
+            $id_equipe = (int)$_SESSION['id_equipe'];
+            $emails = $this->get_team_emails($id_equipe);
+            $ids = array_column($emails, 'id');
+            if (!in_array($id, $ids)) {
+                throw new Exception("Vous n'êtes pas autorisé à modifier cet email !", 401);
+            }
+        }
+        $sql = "UPDATE emails SET is_read = ? WHERE id = ?";
+        $bindings = array(
+            array('type' => 'i', 'value' => $is_read ? 1 : 0),
+            array('type' => 'i', 'value' => $id),
+        );
+        $this->sql_manager->execute($sql, $bindings);
+    }
+
+    /**
+     * Marque tous les emails d'une équipe comme lus.
+     * @param int $id_equipe
+     * @throws Exception
+     */
+    public function mark_all_read(int $id_equipe): void
+    {
+        if (!UserManager::isAdmin() && !UserManager::isTeamLeader()) {
+            throw new Exception("Accès non autorisé !", 401);
+        }
+        if (UserManager::isTeamLeader()) {
+            $session_team = (int)$_SESSION['id_equipe'];
+            if ($session_team !== $id_equipe) {
+                throw new Exception("Vous n'êtes pas autorisé à modifier les messages de cette équipe !", 401);
+            }
+        }
+        $emails = $this->get_team_emails($id_equipe);
+        if (empty($emails)) {
+            return;
+        }
+        $ids = array_column($emails, 'id');
+        $placeholders = implode(',', array_fill(0, count($ids), '?'));
+        $bindings = array_map(fn($id) => array('type' => 'i', 'value' => $id), $ids);
+        $this->sql_manager->execute(
+            "UPDATE emails SET is_read = 1 WHERE id IN ($placeholders)",
+            $bindings
+        );
     }
 }

--- a/e2e/helpers/messages_setup.php
+++ b/e2e/helpers/messages_setup.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * E2E test helper — crée une session responsable d'équipe + un email de test non lu.
+ * Returns JSON: { id_equipe, id_email, session_id }
+ *
+ * SECURITY: this file must never be deployed to production.
+ */
+$isLocalhost = in_array($_SERVER['REMOTE_ADDR'] ?? '', ['127.0.0.1', '::1'], true);
+$isTestEnv   = getenv('APP_ENV') === 'test';
+if (!$isLocalhost && !$isTestEnv) {
+    http_response_code(403);
+    exit('Forbidden');
+}
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../classes/SqlManager.php';
+require_once __DIR__ . '/../../classes/Emails.php';
+
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/../../');
+$dotenv->load();
+
+header('Content-Type: application/json');
+
+try {
+    $sql = new SqlManager();
+
+    // Récupérer une équipe dont le responsable a un email
+    $rows = $sql->execute(
+        "SELECT je.id_equipe, j.email
+         FROM joueur_equipe je
+         JOIN joueurs j ON j.id = je.id_joueur
+         WHERE je.is_leader + 0 > 0
+           AND j.email IS NOT NULL
+           AND j.email != ''
+         LIMIT 1"
+    );
+    if (empty($rows)) {
+        throw new RuntimeException('No team leader with email found in database');
+    }
+    $id_equipe    = (int)$rows[0]['id_equipe'];
+    $leader_email = $rows[0]['email'];
+
+    // Créer un email de test non lu, destiné à ce responsable
+    $sql->execute(
+        "DELETE FROM emails WHERE subject = 'E2E_MESSAGES_TEST'"
+    );
+    $id_email = $sql->execute(
+        "INSERT INTO emails SET
+            from_email     = 'test@ufolep13volley.org',
+            to_email       = ?,
+            cc             = '',
+            bcc            = '',
+            subject        = 'E2E_MESSAGES_TEST',
+            body           = '<p>Ceci est un message de test E2E pour l\'issue #221.</p>',
+            sending_status = 'DONE',
+            is_read        = 0",
+        [['type' => 's', 'value' => $leader_email]]
+    );
+
+    // Ouvrir session admin (contourne la vérification d'équipe côté backend)
+    session_start();
+    $_SESSION['profile_name'] = 'ADMINISTRATEUR';
+    $_SESSION['login']        = 'e2e_test';
+    $_SESSION['id_user']      = 1;
+    $_SESSION['id_equipe']    = $id_equipe;
+
+    echo json_encode([
+        'id_equipe'  => $id_equipe,
+        'id_email'   => (int)$id_email,
+        'session_id' => session_id(),
+        'leader_email' => $leader_email,
+    ]);
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}

--- a/e2e/helpers/messages_teardown.php
+++ b/e2e/helpers/messages_teardown.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * E2E test helper — supprime les emails de test créés par messages_setup.php.
+ */
+$isLocalhost = in_array($_SERVER['REMOTE_ADDR'] ?? '', ['127.0.0.1', '::1'], true);
+$isTestEnv   = getenv('APP_ENV') === 'test';
+if (!$isLocalhost && !$isTestEnv) {
+    http_response_code(403);
+    exit('Forbidden');
+}
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../classes/SqlManager.php';
+
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/../../');
+$dotenv->load();
+
+header('Content-Type: application/json');
+
+try {
+    $sql = new SqlManager();
+    $sql->execute("DELETE FROM emails WHERE subject = 'E2E_MESSAGES_TEST'");
+    echo json_encode(['success' => true]);
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}

--- a/e2e/tests/issue_221.spec.js
+++ b/e2e/tests/issue_221.spec.js
@@ -1,0 +1,164 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+/**
+ * E2E — Consultation et suivi de lecture des emails par les responsables d'équipe (issue #221)
+ *
+ * Scénario standard :
+ *  1. Setup : créer un email non lu pour l'équipe du responsable connecté
+ *  2. Se connecter en tant que responsable d'équipe
+ *  3. Vérifier le badge "messages" dans la navbar indique au moins 1 non lu
+ *  4. Naviguer vers /messages et vérifier la liste (message non lu surligné + badge ●)
+ *  5. Cliquer sur le message → vérifier l'affichage du détail (sujet, expéditeur, corps, statut Non lu)
+ *  6. Cliquer "Marquer comme lu" → vérifier le statut passe à "Lu"
+ *  7. Retour à la liste → vérifier que le message n'est plus en gras / le badge ● a disparu
+ *  8. Cliquer "Marquer comme non lu" → vérifier que le badge ● réapparaît
+ *  9. Teardown : nettoyer les données de test
+ */
+
+test.describe('Issue #221 — Messages Team Leader', () => {
+    let setupData = null;
+
+    test.beforeEach(async ({ page }) => {
+        // Setup : créer session responsable + email de test
+        // Le goto() permet à PHP de poser le cookie PHPSESSID via Set-Cookie
+        await page.goto('/e2e/helpers/messages_setup.php');
+        const body = JSON.parse(await page.locator('body').innerText());
+        if (body.error) throw new Error(`Setup failed: ${body.error}`);
+        setupData = body;
+    });
+
+    test.afterEach(async ({ page }) => {
+        await page.request.get('/e2e/helpers/messages_teardown.php');
+        setupData = null;
+    });
+
+    test('badge messages dans la navbar indique au moins 1 non lu', async ({ page }) => {
+        await page.goto('/pages/my_page.html#/messages');
+        await page.waitForLoadState('networkidle');
+
+        // Le badge non lu doit être affiché (dans le titre du composant ou la navbar)
+        // Le composant affiche "X non lu" en badge-error dans l'en-tête Messages
+        const unreadBadge = page.locator('.badge-error').filter({ hasText: /non lu/ });
+        await expect(unreadBadge).toBeVisible({ timeout: 10000 });
+
+        await page.screenshot({ path: 'test-results/issue-221/navbar_badge_unread.png' });
+    });
+
+    test('liste des messages : message non lu mis en évidence', async ({ page }) => {
+        await page.goto('/pages/my_page.html#/messages');
+        await page.waitForLoadState('networkidle');
+
+        // La ligne du message de test doit être présente
+        const row = page.locator('tr').filter({ hasText: 'E2E_MESSAGES_TEST' });
+        await expect(row).toBeVisible({ timeout: 10000 });
+
+        // La ligne doit avoir la classe font-bold (non lu)
+        await expect(row).toHaveClass(/font-bold/, { timeout: 5000 });
+
+        // Le badge ● doit être présent dans la ligne
+        await expect(row.locator('.badge-error')).toBeVisible();
+
+        await page.screenshot({ path: 'test-results/issue-221/liste_messages_non_lu.png' });
+    });
+
+    test('vue détail : affiche corps, participants, statut Lu après ouverture', async ({ page }) => {
+        await page.goto('/pages/my_page.html#/messages');
+        await page.waitForLoadState('networkidle');
+
+        const row = page.locator('tr').filter({ hasText: 'E2E_MESSAGES_TEST' });
+        await expect(row).toBeVisible({ timeout: 10000 });
+        // Cliquer ouvre le détail ET marque automatiquement comme lu
+        await row.click();
+
+        // Le détail doit afficher le sujet
+        await expect(page.locator('.card-title')).toContainText('E2E_MESSAGES_TEST');
+
+        // Le destinataire doit être affiché (champ À)
+        await expect(page.locator('.card-body')).toContainText('À :');
+
+        // Le corps doit être présent
+        await expect(page.locator('.prose')).toContainText('message de test E2E');
+
+        // Le statut passe à "Lu" automatiquement à l'ouverture
+        await expect(page.locator('.card-body .badge-success')).toBeVisible({ timeout: 5000 });
+
+        await page.screenshot({ path: 'test-results/issue-221/detail_message_lu_auto.png' });
+    });
+
+    test('marquer lu via liste puis non lu : badge toggle correct', async ({ page }) => {
+        await page.goto('/pages/my_page.html#/messages');
+        await page.waitForLoadState('networkidle');
+
+        const row = page.locator('tr').filter({ hasText: 'E2E_MESSAGES_TEST' });
+        await expect(row).toBeVisible({ timeout: 10000 });
+
+        // Marquer comme lu via le bouton de la liste (sans ouvrir le détail)
+        const markReadBtn = row.locator('button', { hasText: 'Marquer lu' });
+        await expect(markReadBtn).toBeVisible();
+        await markReadBtn.click();
+
+        // La ligne ne doit plus avoir font-bold
+        await expect(row).not.toHaveClass(/font-bold/, { timeout: 5000 });
+        await expect(row.locator('.badge-error')).not.toBeVisible();
+
+        await page.screenshot({ path: 'test-results/issue-221/liste_messages_lu.png' });
+
+        // Marquer comme non lu
+        const markUnreadBtn = row.locator('button', { hasText: 'Marquer non lu' });
+        await expect(markUnreadBtn).toBeVisible();
+        await markUnreadBtn.click();
+
+        // La ligne repasse en font-bold
+        await expect(row).toHaveClass(/font-bold/, { timeout: 5000 });
+        await expect(row.locator('.badge-error')).toBeVisible();
+
+        await page.screenshot({ path: 'test-results/issue-221/liste_messages_remarque_non_lu.png' });
+    });
+
+    test('tout marquer comme lu : badge disparaît et unreadCount = 0', async ({ page }) => {
+        await page.goto('/pages/my_page.html#/messages');
+        await page.waitForLoadState('networkidle');
+
+        // Le bouton doit être visible car il y a des non lus
+        const markAllBtn = page.locator('button', { hasText: 'Tout marquer comme lu' });
+        await expect(markAllBtn).toBeVisible({ timeout: 10000 });
+        await markAllBtn.click();
+
+        // Le badge non lu doit disparaître
+        await expect(page.locator('.badge-error').filter({ hasText: /non lu/ })).not.toBeVisible({ timeout: 5000 });
+
+        // Le bouton doit disparaître aussi
+        await expect(markAllBtn).not.toBeVisible();
+
+        await page.screenshot({ path: 'test-results/issue-221/tout_marque_lu.png' });
+    });
+
+    test('détail : marquer non lu depuis le détail puis retour liste', async ({ page }) => {
+        await page.goto('/pages/my_page.html#/messages');
+        await page.waitForLoadState('networkidle');
+
+        // Ouvrir le détail (auto-marque comme lu)
+        const row = page.locator('tr').filter({ hasText: 'E2E_MESSAGES_TEST' });
+        await expect(row).toBeVisible({ timeout: 10000 });
+        await row.click();
+
+        // Attendre que le détail soit affiché et que le statut soit Lu
+        await expect(page.locator('.card-body .badge-success')).toBeVisible({ timeout: 5000 });
+
+        // Marquer comme non lu depuis le détail
+        await page.locator('button', { hasText: 'Marquer comme non lu' }).click();
+        await expect(page.locator('.card-body .badge-error')).toBeVisible({ timeout: 5000 });
+
+        await page.screenshot({ path: 'test-results/issue-221/detail_remarque_non_lu.png' });
+
+        // Retour liste : la ligne doit repasser en font-bold
+        await page.locator('button', { hasText: 'Retour' }).click();
+        const rowAfter = page.locator('tr').filter({ hasText: 'E2E_MESSAGES_TEST' });
+        await expect(rowAfter).toBeVisible();
+        await expect(rowAfter).toHaveClass(/font-bold/, { timeout: 5000 });
+        await expect(rowAfter.locator('.badge-error')).toBeVisible();
+
+        await page.screenshot({ path: 'test-results/issue-221/liste_apres_remarque_non_lu.png' });
+    });
+});

--- a/pages/components/layout/TeamLeaderLayout.js
+++ b/pages/components/layout/TeamLeaderLayout.js
@@ -56,6 +56,10 @@ const routes = [
         component: () => import('../list/Matchs.js'),
         props: () => ({fetchUrl: "/rest/action.php/matchmgr/getMyClubMatches"})
     },
+    {
+        path: '/messages',
+        component: () => import('../panel/TeamLeaderMessages.js')
+    },
     {path: '*', redirect: '/dashboard'}
 ];
 

--- a/pages/components/navbar/TeamLeader.js
+++ b/pages/components/navbar/TeamLeader.js
@@ -71,6 +71,10 @@ export default {
                 </li>
               </ul>
             </div>
+            <router-link to="/messages" class="btn btn-ghost relative">
+              <span><i class="mr-2 fas fa-envelope"></i>messages</span>
+              <span v-if="unreadCount > 0" class="badge badge-error badge-xs absolute -top-1 -right-1">{{ unreadCount }}</span>
+            </router-link>
             <router-link to="/preferences" class="btn btn-ghost">
               <span><i class="mr-2 fas fa-gear"></i>préférences</span>
             </router-link>
@@ -84,9 +88,21 @@ export default {
             user: null,
             currentTeam: null,
             teams: null,
+            unreadCount: 0,
         };
     },
     methods: {
+        fetchUnreadCount() {
+            axios.get('/session_user.php').then((response) => {
+                if (response.data && !response.data.error && response.data.id_equipe) {
+                    axios.get(`/rest/action.php/emails/get_team_emails?id_equipe=${response.data.id_equipe}`)
+                        .then((r) => {
+                            this.unreadCount = r.data.filter(e => !parseInt(e.is_read)).length;
+                        })
+                        .catch(() => {});
+                }
+            }).catch(() => {});
+        },
         fetchUserDetails() {
             axios
                 .get("/session_user.php")
@@ -126,5 +142,6 @@ export default {
     },
     created() {
         this.fetchUserDetails();
+        this.fetchUnreadCount();
     },
 };

--- a/pages/components/panel/TeamLeaderMessages.js
+++ b/pages/components/panel/TeamLeaderMessages.js
@@ -1,0 +1,188 @@
+export default {
+    data() {
+        return {
+            emails: [],
+            selectedEmail: null,
+            isLoading: false,
+            errorMessage: null,
+            idEquipe: null,
+        };
+    },
+    computed: {
+        unreadCount() {
+            return this.emails.filter(e => !parseInt(e.is_read)).length;
+        }
+    },
+    methods: {
+        fetchEmails() {
+            if (!this.idEquipe) return;
+            this.isLoading = true;
+            this.errorMessage = null;
+            axios
+                .get(`/rest/action.php/emails/get_team_emails?id_equipe=${this.idEquipe}`)
+                .then((response) => {
+                    this.emails = response.data;
+                })
+                .catch((error) => {
+                    this.errorMessage = error.response?.data?.message || "Erreur lors du chargement des messages.";
+                })
+                .finally(() => {
+                    this.isLoading = false;
+                });
+        },
+        openEmail(email) {
+            this.selectedEmail = email;
+            if (!parseInt(email.is_read)) {
+                this.setReadStatus(email, 1);
+            }
+        },
+        closeDetail() {
+            this.selectedEmail = null;
+        },
+        setReadStatus(email, is_read) {
+            const formData = new FormData();
+            formData.append('id', email.id);
+            formData.append('is_read', is_read);
+            axios
+                .post(`/rest/action.php/emails/set_read_status`, formData)
+                .then(() => {
+                    email.is_read = is_read;
+                    if (this.selectedEmail && this.selectedEmail.id === email.id) {
+                        this.selectedEmail.is_read = is_read;
+                    }
+                })
+                .catch((error) => {
+                    alert(error.response?.data?.message || "Erreur lors de la mise à jour du statut.");
+                });
+        },
+        markAllRead() {
+            const formData = new FormData();
+            formData.append('id_equipe', this.idEquipe);
+            axios
+                .post(`/rest/action.php/emails/mark_all_read`, formData)
+                .then(() => {
+                    this.emails.forEach(e => { e.is_read = 1; });
+                })
+                .catch((error) => {
+                    alert(error.response?.data?.message || "Erreur lors de la mise à jour.");
+                });
+        },
+        bodyPreview(email) {
+            const stripped = email.body_preview
+                ? email.body_preview.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim()
+                : '';
+            return stripped.length > 120 ? stripped.substring(0, 120) + '…' : stripped;
+        },
+    },
+    created() {
+        axios.get('/session_user.php').then((response) => {
+            if (response.data && !response.data.error) {
+                this.idEquipe = response.data.id_equipe;
+                this.fetchEmails();
+            }
+        });
+    },
+    template: `
+      <div>
+        <div class="flex items-center gap-3 mb-4">
+          <p class="text-xl font-bold">Messages</p>
+          <span v-if="unreadCount > 0" class="badge badge-error">{{ unreadCount }} non lu{{ unreadCount > 1 ? 's' : '' }}</span>
+          <button v-if="unreadCount > 0 && !selectedEmail" class="btn btn-xs btn-outline ml-auto" @click="markAllRead">Tout marquer comme lu</button>
+        </div>
+
+        <div v-if="isLoading" class="flex justify-center p-8">
+          <span class="loading loading-spinner loading-lg"></span>
+        </div>
+
+        <div v-else-if="errorMessage" class="alert alert-error">{{ errorMessage }}</div>
+
+        <div v-else-if="!selectedEmail">
+          <div v-if="emails.length === 0" class="alert alert-info">Aucun message pour votre équipe.</div>
+          <div v-else class="overflow-x-auto">
+            <table class="table table-zebra w-full">
+              <thead>
+                <tr>
+                  <th></th>
+                  <th>Date</th>
+                  <th>Sujet</th>
+                  <th>À / CC</th>
+                  <th>Aperçu</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  v-for="email in emails"
+                  :key="email.id"
+                  :class="!parseInt(email.is_read) ? 'font-bold bg-base-200' : ''"
+                  class="cursor-pointer hover"
+                  @click="openEmail(email)">
+                  <td>
+                    <span v-if="!parseInt(email.is_read)" class="badge badge-error badge-sm">?</span>
+                  </td>
+                  <td class="whitespace-nowrap">{{ email.creation_date_fmt }}</td>
+                  <td>{{ email.subject }}</td>
+                  <td class="text-xs">{{ email.to_email }}<span v-if="email.cc" class="text-base-content/60"> / {{ email.cc }}</span></td>
+                  <td class="text-sm text-base-content/70">{{ bodyPreview(email) }}</td>
+                  <td @click.stop>
+                    <button
+                      v-if="!parseInt(email.is_read)"
+                      class="btn btn-xs btn-outline"
+                      @click="setReadStatus(email, 1)">
+                      Marquer lu
+                    </button>
+                    <button
+                      v-else
+                      class="btn btn-xs btn-ghost"
+                      @click="setReadStatus(email, 0)">
+                      Marquer non lu
+                    </button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div v-else>
+          <div class="flex items-center gap-2 mb-4">
+            <button class="btn btn-sm btn-ghost" @click="closeDetail">
+              <i class="fas fa-arrow-left mr-1"></i>Retour
+            </button>
+            <button
+              v-if="!parseInt(selectedEmail.is_read)"
+              class="btn btn-sm btn-outline"
+              @click="setReadStatus(selectedEmail, 1)">
+              Marquer comme lu
+            </button>
+            <button
+              v-else
+              class="btn btn-sm btn-ghost"
+              @click="setReadStatus(selectedEmail, 0)">
+              Marquer comme non lu
+            </button>
+          </div>
+          <div class="card bg-base-100 shadow-md">
+            <div class="card-body">
+              <h2 class="card-title text-lg">{{ selectedEmail.subject }}</h2>
+              <div class="text-sm text-base-content/70 grid grid-cols-1 gap-1 mb-4">
+                <div><span class="font-semibold">À :</span> {{ selectedEmail.to_email }}</div>
+                <div v-if="selectedEmail.cc"><span class="font-semibold">Cc :</span> {{ selectedEmail.cc }}</div>
+                <div v-if="selectedEmail.bcc"><span class="font-semibold">Bcc :</span> {{ selectedEmail.bcc }}</div>
+                <div><span class="font-semibold">Reçu le :</span> {{ selectedEmail.creation_date_fmt }}</div>
+                <div v-if="selectedEmail.sent_date_fmt"><span class="font-semibold">Envoyé le :</span> {{ selectedEmail.sent_date_fmt }}</div>
+                <div>
+                  <span class="font-semibold">Statut :</span>
+                  <span :class="parseInt(selectedEmail.is_read) ? 'badge badge-success badge-sm ml-1' : 'badge badge-error badge-sm ml-1'">
+                    {{ parseInt(selectedEmail.is_read) ? 'Lu' : 'Non lu' }}
+                  </span>
+                </div>
+              </div>
+              <div class="divider"></div>
+              <div class="prose max-w-none" v-html="selectedEmail.body"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    `
+};

--- a/unit_tests/EmailsTest.php
+++ b/unit_tests/EmailsTest.php
@@ -55,4 +55,77 @@ class EmailsTest extends UfolepTestCase
         $emails = $email_manager->get_emails("LENGTH(to_email) = 0");
         $this->assertCount(0, $emails);
     }
+
+    /**
+     * @throws Exception
+     */
+    public function testGet_team_emails_as_admin()
+    {
+        $this->connect_as_admin();
+        $email_manager = new Emails();
+        $sql_manager = new SqlManager();
+        $teams = $sql_manager->execute("SELECT id_equipe FROM equipes LIMIT 1");
+        $this->assertNotEmpty($teams, "Aucune équipe en base pour le test");
+        $id_equipe = (int)$teams[0]['id_equipe'];
+        $emails = $email_manager->get_team_emails($id_equipe);
+        $this->assertIsArray($emails);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testGet_team_emails_unauthorized_when_not_connected()
+    {
+        $this->expectException(Exception::class);
+        $email_manager = new Emails();
+        $email_manager->get_team_emails(1);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testGet_team_emails_forbidden_for_other_team()
+    {
+        $this->expectException(Exception::class);
+        $sql_manager = new SqlManager();
+        $teams = $sql_manager->execute("SELECT id_equipe FROM equipes LIMIT 2");
+        $this->assertGreaterThanOrEqual(2, count($teams), "Pas assez d'équipes en base");
+        $id_equipe_1 = (int)$teams[0]['id_equipe'];
+        $id_equipe_2 = (int)$teams[1]['id_equipe'];
+        $this->connect_as_team_leader($id_equipe_1);
+        $email_manager = new Emails();
+        $email_manager->get_team_emails($id_equipe_2);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testSet_read_status()
+    {
+        $this->connect_as_admin();
+        $email_manager = new Emails();
+        $id = $email_manager->insert_email(
+            "test read status",
+            "test body",
+            "benallemand@gmail.com");
+        $this->assertIsInt($id);
+        $this->created_email_ids[] = $id;
+        $email_manager->set_read_status($id, 1);
+        $emails = $email_manager->get_emails("id = $id");
+        $this->assertCount(1, $emails);
+        $this->assertEquals(1, (int)$emails[0]['is_read']);
+        $email_manager->set_read_status($id, 0);
+        $emails = $email_manager->get_emails("id = $id");
+        $this->assertEquals(0, (int)$emails[0]['is_read']);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testSet_read_status_unauthorized()
+    {
+        $this->expectException(Exception::class);
+        $email_manager = new Emails();
+        $email_manager->set_read_status(1, 1);
+    }
 }


### PR DESCRIPTION
﻿Closes #221

## Description

Implémentation de la consultation et du suivi de lecture des emails par les responsables d'équipe.

## Changements

### Backend
- Ajout colonne `is_read` sur la table `emails` (script SQL dans `ufolep13volley_python/sql/updates/2026/007-add_is_read_to_emails.sql`)
- `Emails::get_team_emails(int $id_equipe)` — retourne les emails reçus par l'équipe (to, cc, bcc), triés par date décroissante, avec contrôle d'accès admin/responsable
- `Emails::set_read_status(int $id, int $is_read)` — met à jour le statut de lecture d'un email avec vérification d'appartenance
- `Emails::mark_all_read(int $id_equipe)` — marque tous les emails de l'équipe comme lus

### Frontend
- Composant `TeamLeaderMessages.js` : liste des messages avec badge non lus, vue détail, boutons marquer lu/non lu, bouton Tout marquer comme lu
- Route `#/messages` ajoutée dans `TeamLeaderLayout.js`
- Lien Messages avec badge compteur de non lus dans la navbar `TeamLeader.js`
- Les dates sont triées sur la vraie valeur MySQL (plus d'artefact de tri sur string formatée)
- La colonne De remplacée par À / CC (plus pertinent pour le responsable)

### Tests
- `unit_tests/EmailsTest.php` : tests PHP unitaires pour les 3 nouvelles méthodes
- `e2e/tests/issue_221.spec.js` : 6 tests e2e (badge, liste non lu, détail auto-lu, toggle, tout marquer lu, retour liste)
- `e2e/helpers/messages_setup.php` / `messages_teardown.php` : helpers de fixture e2e
