### PR TITLE
feat(#223): migration frontend Node.js + Vite + Vue 3, suppression des CDN

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Dépendances locales (les images Docker font leurs propres install)
+node_modules/
+vendor/
+e2e/node_modules/
+
+# Build frontend : ne JAMAIS copier le dist/ local — il sera produit par
+# l'étape multi-stage Node du Dockerfile et copié dans l'image PHP finale.
+dist/
+
+# Git / IDE / OS
+.git/
+.github/
+.idea/
+.vscode/
+.DS_Store
+
+# Environnement
+.env
+.env.*
+
+# Tests
+e2e/test-results/
+e2e/report/
+e2e/playwright-report/
+.phpunit.result.cache
+
+# Données locales / dev
+docker-sql/ufolepvocbufolep-data-only.sql
+caddy.exe
+pr_body.md
+
+# Composants ignorés par git
+players_pics/
+players_pics_low/
+teams_pics/
+match_files/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI — Frontend build check
+
+# Valide que `npm ci` + `npm run build` passe sur le runner GH Actions
+# AVANT qu'un tag de release ne declenche le deploiement (main.yml).
+# Sans deploiement, donc safe : on apprend si le build CI marche sans
+# risquer la prod.
+
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - master  # master est deja couvert par main.yml au moment du tag
+
+jobs:
+  build:
+    name: Build frontend bundle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install frontend dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Build frontend bundle
+        run: npm run build
+
+      - name: Verify build output
+        # Sanity check : on confirme que les fichiers attendus sont produits.
+        run: |
+          test -f dist/.vite/manifest.json || (echo "ERREUR : manifest.json manquant" && exit 1)
+          test -f dist/pages/home.html || (echo "ERREUR : dist/pages/home.html manquant" && exit 1)
+          test -f dist/pages/my_page.html || (echo "ERREUR : dist/pages/my_page.html manquant" && exit 1)
+          test -f dist/admin/matches.html || (echo "ERREUR : dist/admin/matches.html manquant" && exit 1)
+          ls -la dist/assets/ | head -20
+          echo ""
+          echo "Build OK. dist/ contient :"
+          du -sh dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,21 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install frontend dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Build frontend bundle
+        # Produit dist/ : JS/CSS minifies + hashes + dist/.vite/manifest.json.
+        # Necessaire car le helper PHP vite_asset() et le rewrite .htaccess
+        # pointent vers /dist/. Le dist/ n'est pas versionne.
+        run: npm run build
+
       - name: Setup SSH
         uses: webfactory/ssh-agent@v0.8.0
         with:
@@ -25,7 +40,14 @@ jobs:
           mkdir -p ~/.ssh
           ssh-keyscan ftp.cluster020.hosting.ovh.net >> ~/.ssh/known_hosts
 
-      - name: Deploy to production
+      - name: Sync frontend bundle to OVH
+        # rsync AVANT le git pull pour que dist/ soit en place quand le
+        # nouveau code source (HTML/PHP) commence a y faire reference.
+        # --delete pour purger les vieux fichiers hashes du build precedent.
+        run: |
+          rsync -avz --delete dist/ ufolepvocb@ftp.cluster020.hosting.ovh.net:www/dist/
+
+      - name: Deploy source code (git pull on OVH)
         run: |
           ssh ufolepvocb@ftp.cluster020.hosting.ovh.net "cd www && if git ls-files --error-unmatch composer.phar >/dev/null 2>&1; then git checkout -- composer.phar; else rm -f composer.phar; fi && git pull"
           echo "Deployment completed successfully!"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,10 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')  # Exécute uniquement si déclenché par un tag
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ e2e/node_modules/
 e2e/package-lock.json
 e2e/test-results/
 e2e/report/
+
+# Frontend build (Vite)
+node_modules/
+dist/

--- a/.htaccess
+++ b/.htaccess
@@ -1,3 +1,10 @@
 AddDefaultCharset UTF-8
 
 RedirectMatch 404 /\.git
+
+# Bundles Vite des pages HTML pures : on conserve les URLs publiques
+# (/pages/home.html, /pages/my_page.html, /admin/matches.html) mais le
+# contenu servi est le HTML transformé par Vite dans dist/.
+RewriteEngine On
+RewriteRule ^pages/(home|my_page)\.html$ /dist/pages/$1.html [L]
+RewriteRule ^admin/matches\.html$ /dist/admin/matches.html [L]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,8 @@ Application web de gestion des championnats de volleyball UFOLEP 13.
 ## Stack Technique
 
 - **Backend** : PHP 8.1, MySQL
-- **Frontend client** : Vue.js 2, Tailwind CSS, DaisyUI
-- **Frontend admin** : Sencha/ExtJS (interface d'administration)
+- **Frontend client** : Vue.js 3, Tailwind CSS, DaisyUI — bundlé via Vite (Node.js 20)
+- **Frontend admin** : Sencha/ExtJS (interface d'administration historique, CDN — non bundlé)
 - **Tests unitaires** : PHPUnit (`unit_tests/`)
 - **Tests E2E** : Playwright (`e2e/`)
 - **Reverse proxy local** : Caddy (Docker)
@@ -33,6 +33,11 @@ js/               # JavaScript admin (ExtJS/Sencha)
   store/          # Stores ExtJS
 admin/            # Interface admin Vue.js moderne (en cours de migration)
   components/     # Web components JS
+src/              # Sources Vite (CSS global)
+  css/app.css     # Tailwind + DaisyUI + libs tierces
+helpers/          # Helpers PHP
+  vite.php        # vite_asset() : lit dist/.vite/manifest.json
+dist/             # Bundle Vite (gitignored — produit par `npm run build`)
 unit_tests/       # Tests PHPUnit
 e2e/              # Tests E2E Playwright
   tests/          # Specs (.spec.js), un fichier par ticket/feature
@@ -104,6 +109,30 @@ c:\php\php.exe composer.phar install
 c:\php\php.exe composer.phar update
 ```
 
+### Frontend bundlé (Vite)
+
+Le frontend Vue 3 est bundlé par Vite. Les pages PHP utilisent le helper `vite_asset()` (dans `helpers/vite.php`) pour émettre les balises `<script>` / `<link>` vers les fichiers hashés ; les pages HTML pures (home, my_page, admin/matches) sont des entrées HTML natives Vite et un `.htaccess` rewrite leurs URLs publiques vers `/dist/`.
+
+**Installer les dépendances Node**
+```bash
+npm ci    # apres un git pull, pour respecter le lockfile
+npm install   # pour ajouter/retirer un paquet
+```
+
+**Builder le bundle** (produit `dist/` minifié + hashé + `dist/.vite/manifest.json`)
+```bash
+npm run build
+```
+
+> **Important** : le `dist/` n'est PAS versionné (.gitignore). Il faut le rebuild après chaque modification du code frontend. En Docker, le `Dockerfile` build automatiquement le `dist/` via une étape multi-stage `node:20-alpine`. En CI (`.github/workflows/main.yml`), GitHub Actions build et rsync `dist/` vers OVH avant le `git pull` du code source.
+
+**Entrées déclarées dans `vite.config.js`** :
+- `src/css/app.css` — Tailwind + DaisyUI + libs tierces (FontAwesome, Notyf, Toastify)
+- `live.js`, `match.js`, `survey.js`, `team_sheets.js` — entrées JS pour les pages .php (chargées via `vite_asset('live.js')` etc.)
+- `pages/home.html`, `pages/my_page.html`, `admin/matches.html` — entrées HTML natives Vite
+
+**Hors périmètre du bundle Vite** : `admin.php`, `register.php`, `reset_password.php`, `rank_for_cup.php` — restent sur les CDN ExtJS (interface d'administration historique).
+
 ### Déployer en production
 ```bash
 # Créer un tag pour déclencher le CI/CD
@@ -148,10 +177,14 @@ class MonTest extends UfolepTestCase {
 
 ## Frontend Vue.js (pages publiques)
 
-- Vue.js 2 chargé via CDN
+- Vue.js 3 (Options API) bundlé par Vite — plus aucun CDN externe en prod
 - Tailwind CSS + DaisyUI pour les composants UI
-- Fichiers `.js` à la racine ou dans `pages/components/` pour les composants
+- Fichiers `.js` à la racine (`live.js`, `match.js`, ...) ou dans `pages/components/`
 - Communication parent→enfant : props ; enfant→parent : `$emit()`
+- Templates en string (`template: '...'`) dans les composants — `vite.config.js` alias `vue` → `vue/dist/vue.esm-bundler.js` pour inclure le compilateur de templates
+- Composants async via `defineAsyncComponent(() => import(...))` (pas `() => import(...)` direct — pas supporté en Vue 3)
+- `axios`, `Toastify`, `Notyf` exposés sur `window` par chaque entrée pour préserver l'usage en globaux dans les sous-composants
+- `dist/` produit par `npm run build` (voir section "Commandes essentielles")
 
 ## Frontend ExtJS (admin)
 
@@ -164,6 +197,58 @@ class MonTest extends UfolepTestCase {
 - Repository : https://github.com/benallemand/ufolep13volley
 - Issues : https://github.com/benallemand/ufolep13volley/issues
 - CI/CD : `.github/workflows/main.yml` (déclenchement par tag)
+
+## Bonnes Pratiques Apprises
+
+### Identifiants de Match
+- Les `id_match` peuvent être des chaînes (ex: `C_9_20260122_040`), pas seulement des entiers
+- Utiliser `VARCHAR(20)` pour stocker les `code_match` en base
+- Dans l'API PHP, utiliser `FILTER_SANITIZE_FULL_SPECIAL_CHARS` au lieu de `FILTER_VALIDATE_INT`
+- Utiliser `get_match_by_code_match()` plutôt que `get_match()` pour les requêtes par code
+
+### Boutons Conditionnels (Vue.js)
+- Vérifier la date du jour : `new Date().toLocaleDateString('fr-FR')` pour comparer avec les dates au format `dd/mm/yyyy`
+- Masquer les boutons quand l'action n'est plus pertinente (ex: match terminé)
+- Utiliser `animate-pulse` de Tailwind pour attirer l'attention
+
+### Autorisation Multi-Niveau
+- Vérifier côté backend ET frontend
+- Pattern : Admin OU responsable de l'équipe concernée
+- Stocker `id_equipe` en session pour les vérifications
+
+### Debug de Features en Temps Réel
+- Créer un fichier `debug_{feature}.php` pour tester/modifier les données temporairement
+- Permet de mettre à jour les dates pour simuler "aujourd'hui"
+
+### Requêtes AJAX ExtJS
+- Toujours spécifier `method: 'GET'` pour les lectures, `method: 'POST'` pour les écritures
+- Par défaut ExtJS utilise POST, ce qui n'est pas toujours approprié
+
+### Validation d'ID en PHP
+- Utiliser `!empty($id) && is_numeric($id)` pour vérifier les IDs de base de données
+- ExtJS génère des IDs temporaires comme `"extModel1124-23"` pour les nouveaux records
+- `isset()` retourne true même pour `null`, préférer `!empty()`
+
+### Tests Unitaires Sélectifs
+- Certains tests sont destructifs (modification de données réelles)
+- Préférer exécuter les tests spécifiques : `--filter "test_method1|test_method2"`
+- Éviter `phpunit unit_tests/` si la base contient des données de production
+
+### Routeur REST PHP et Paramètres Nommés
+- Le routeur `rest/action.php` appelle les méthodes avec des **paramètres nommés** PHP 8+
+- Les méthodes CRUD doivent accepter les paramètres comme arguments de fonction, pas via `$_POST`
+- Exemple : `public function saveNews($id = null, $title = '', $text = ''): void`
+- ExtJS envoie automatiquement `$dirtyFields` lors du submit — l'ajouter comme paramètre optionnel
+
+### Frontend ExtJS — Patterns Admin
+- **Grilles admin** : utiliser des fenêtres d'édition modales (pattern `window.Window`), pas le plugin `rowediting`
+- Créer : `js/view/{entity}/AdminGrid.js` pour la grille, `js/view/{entity}/Edit.js` pour la fenêtre modale
+- Ajouter les refs : `formPanelEdit{Entity}`, `windowEdit{Entity}`, `manage{Entity}Grid`
+
+### GitHub CLI
+- Pour créer une issue/PR via `gh`, rédiger le body dans un fichier `.md` temporaire puis utiliser `--body-file`
+- Ne pas utiliser `--body` inline (problèmes d'échappement)
+- Supprimer le fichier temporaire après usage
 
 ## Points d'attention
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,19 @@
-FROM composer as builder
+# Étape 1 : dépendances PHP (Composer)
+FROM composer as composer_builder
 WORKDIR /app/
 COPY composer.* ./
 RUN composer install --ignore-platform-reqs
 
-# Utiliser l'image officielle PHP
+# Étape 2 : build frontend (Vite)
+# Produit le dossier /app/dist (JS/CSS minifiés + manifest.json hashé).
+FROM node:20-alpine AS frontend_builder
+WORKDIR /app/
+COPY package.json package-lock.json* ./
+RUN npm install --no-audit --no-fund
+COPY . .
+RUN npm run build
+
+# Étape 3 : image PHP finale
 FROM php:8.1-apache
 
 # Installer les extensions PHP nécessaires
@@ -14,4 +24,5 @@ RUN apt-get update && apt-get install -y libpng-dev libjpeg-dev libfreetype6-dev
 
 # Copier les fichiers de notre site dans le conteneur
 COPY . /var/www/html/
-COPY --from=builder /app/vendor /var/www/html/vendor
+COPY --from=composer_builder /app/vendor /var/www/html/vendor
+COPY --from=frontend_builder /app/dist /var/www/html/dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,10 @@ RUN apt-get update && apt-get install -y libpng-dev libjpeg-dev libfreetype6-dev
     && docker-php-ext-install gd mysqli pdo pdo_mysql \
     && rm -rf /var/lib/apt/lists/*
 
+# mod_rewrite : requis pour les RewriteRule du .htaccess
+# (mapping /pages/home.html -> /dist/pages/home.html etc.)
+RUN a2enmod rewrite
+
 # Copier les fichiers de notre site dans le conteneur
 COPY . /var/www/html/
 COPY --from=composer_builder /app/vendor /var/www/html/vendor

--- a/admin/matches.html
+++ b/admin/matches.html
@@ -4,11 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Validation des matchs</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/daisyui@4.12.22/dist/full.css">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+    <link rel="stylesheet" href="../src/css/app.css">
 </head>
 <body class="bg-base-100">
 <div id="match-app" class="container mx-auto p-4">
@@ -113,6 +109,6 @@
         </li>
     </ul>
 </div>
-<script src="/admin/matches.js" type="module"></script>
+<script src="./matches.js" type="module"></script>
 </body>
 </html>

--- a/admin/matches.html
+++ b/admin/matches.html
@@ -7,7 +7,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/daisyui@4.12.22/dist/full.css">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/vue@2/dist/vue.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
 </head>
 <body class="bg-base-100">

--- a/admin/matches.js
+++ b/admin/matches.js
@@ -1,7 +1,12 @@
 // Import du composant admin-match-card
+import { createApp } from 'vue';
+import axios from 'axios';
 import AdminMatchCard from './components/admin-match-card.js';
 
-Vue.createApp({
+// Expose axios en global pour les sous-composants qui l'utilisent sans import
+window.axios = axios;
+
+createApp({
     components: {
         'admin-match-card': AdminMatchCard
     },

--- a/admin/matches.js
+++ b/admin/matches.js
@@ -1,30 +1,31 @@
 // Import du composant admin-match-card
 import AdminMatchCard from './components/admin-match-card.js';
 
-new Vue({
-    el: '#match-app',
+Vue.createApp({
     components: {
         'admin-match-card': AdminMatchCard
     },
-    data: {
-        searchQuery: "",
-        matches: [],
-        loadingMatch: null,
-        loading: false,
-        filter: {
-            selectedCompetition: "",
-            selectedDivision: "",
-            showCertified: false,
-            showNotCertified: false,
-            showForbiddenPlayer: false,
-            showPlayedMatchesOnly: false,
-            showCertifiable: false,
-            showInProgress: true,
-        },
-        user: null,
-        availableCompetitions: [],
-        availableDivisions: [],
-        allMatches: [],
+    data() {
+        return {
+            searchQuery: "",
+            matches: [],
+            loadingMatch: null,
+            loading: false,
+            filter: {
+                selectedCompetition: "",
+                selectedDivision: "",
+                showCertified: false,
+                showNotCertified: false,
+                showForbiddenPlayer: false,
+                showPlayedMatchesOnly: false,
+                showCertifiable: false,
+                showInProgress: true,
+            },
+            user: null,
+            availableCompetitions: [],
+            availableDivisions: [],
+            allMatches: [],
+        };
     },
     computed: {
         canValidate() {
@@ -189,4 +190,4 @@ new Vue({
         this.fetchAllMatches();
         this.fetchMatches();
     },
-});
+}).mount('#match-app');

--- a/helpers/vite.php
+++ b/helpers/vite.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Helper d'intégration Vite côté PHP.
+ *
+ * Deux modes :
+ *
+ *  - Mode dev (variable d'env APP_ENV=dev) : on pointe les <script>/<link>
+ *    vers le dev server Vite (par défaut http://localhost:5173). HMR actif.
+ *
+ *  - Mode prod (défaut) : on lit `dist/.vite/manifest.json` produit par
+ *    `npm run build` et on émet les <script>/<link> avec les fichiers hashés.
+ *
+ * Usage type dans une page PHP :
+ *
+ *     <?php require_once __DIR__ . '/../helpers/vite.php'; ?>
+ *     <head>
+ *         <?= vite_assets(['pages/home.js', 'css/app.css']) ?>
+ *     </head>
+ */
+
+if (!function_exists('vite_is_dev')) {
+    function vite_is_dev(): bool
+    {
+        $env = getenv('APP_ENV');
+        if ($env === false) {
+            $env = $_ENV['APP_ENV'] ?? $_SERVER['APP_ENV'] ?? null;
+        }
+        return $env === 'dev';
+    }
+}
+
+if (!function_exists('vite_dev_server_url')) {
+    function vite_dev_server_url(): string
+    {
+        $url = getenv('VITE_DEV_SERVER_URL');
+        if ($url === false || $url === '') {
+            $url = $_ENV['VITE_DEV_SERVER_URL'] ?? $_SERVER['VITE_DEV_SERVER_URL'] ?? 'http://localhost:5173';
+        }
+        return rtrim($url, '/');
+    }
+}
+
+if (!function_exists('vite_manifest')) {
+    function vite_manifest(): array
+    {
+        static $manifest = null;
+        if ($manifest !== null) {
+            return $manifest;
+        }
+        $path = __DIR__ . '/../dist/.vite/manifest.json';
+        if (!is_file($path)) {
+            // Pas encore buildé : on retourne un manifest vide. Les balises émises
+            // pointeront alors vers /dist/{entry} en best-effort pour ne pas casser
+            // les pages en dev sans Vite.
+            $manifest = [];
+            return $manifest;
+        }
+        $raw = file_get_contents($path);
+        $manifest = json_decode($raw, true) ?: [];
+        return $manifest;
+    }
+}
+
+if (!function_exists('vite_asset')) {
+    /**
+     * Émet la ou les balises HTML correspondant à une entrée Vite.
+     *
+     * En dev : pointe vers le dev server (HMR).
+     * En prod : utilise le manifest.json (fichiers hashés + CSS associés).
+     */
+    function vite_asset(string $entry): string
+    {
+        if (vite_is_dev()) {
+            $base = vite_dev_server_url();
+            $html = '<script type="module" src="' . htmlspecialchars($base . '/@vite/client', ENT_QUOTES) . '"></script>' . "\n";
+            $html .= '<script type="module" src="' . htmlspecialchars($base . '/' . ltrim($entry, '/'), ENT_QUOTES) . '"></script>';
+            return $html;
+        }
+
+        $manifest = vite_manifest();
+        if (!isset($manifest[$entry])) {
+            // Fallback : on émet une référence directe pour aider au debug.
+            return '<!-- vite_asset: entrée "' . htmlspecialchars($entry, ENT_QUOTES) . '" absente du manifest -->';
+        }
+
+        $info = $manifest[$entry];
+        $html = '';
+
+        // CSS importé par l'entrée JS
+        if (!empty($info['css'])) {
+            foreach ($info['css'] as $cssFile) {
+                $html .= '<link rel="stylesheet" href="/dist/' . htmlspecialchars($cssFile, ENT_QUOTES) . '">' . "\n";
+            }
+        }
+
+        $file = $info['file'] ?? null;
+        if ($file === null) {
+            return $html;
+        }
+
+        // Entrée CSS pure
+        if (str_ends_with($file, '.css')) {
+            $html .= '<link rel="stylesheet" href="/dist/' . htmlspecialchars($file, ENT_QUOTES) . '">';
+            return $html;
+        }
+
+        // Entrée JS
+        $html .= '<script type="module" src="/dist/' . htmlspecialchars($file, ENT_QUOTES) . '"></script>';
+
+        // Modules importés (preload pour limiter les waterfalls réseau)
+        if (!empty($info['imports'])) {
+            foreach ($info['imports'] as $importedKey) {
+                if (!isset($manifest[$importedKey]['file'])) {
+                    continue;
+                }
+                $importedFile = $manifest[$importedKey]['file'];
+                $html .= "\n" . '<link rel="modulepreload" href="/dist/' . htmlspecialchars($importedFile, ENT_QUOTES) . '">';
+            }
+        }
+
+        return $html;
+    }
+}
+
+if (!function_exists('vite_assets')) {
+    /**
+     * Émet plusieurs entrées d'un coup.
+     *
+     * @param string[] $entries
+     */
+    function vite_assets(array $entries): string
+    {
+        return implode("\n", array_map('vite_asset', $entries));
+    }
+}

--- a/live.js
+++ b/live.js
@@ -1,7 +1,14 @@
+import { createApp } from 'vue';
+import axios from 'axios';
+import Toastify from 'toastify-js';
 import ScoreBoard from './pages/components/live/ScoreBoard.js';
 import ScorerControls from './pages/components/live/ScorerControls.js';
 import ActiveMatchList from './pages/components/live/ActiveMatchList.js';
 import MatchDetails from './pages/components/live/MatchDetails.js';
+
+// Expose les libs en global pour les sous-composants qui les utilisent sans import
+window.axios = axios;
+window.Toastify = Toastify;
 
 const liveData = window.__LIVE_DATA__ || {};
 const ROTATION_COMPETITION_CODES = ['m', 'c', 'cf'];
@@ -17,7 +24,7 @@ function createEmptyLineup() {
     };
 }
 
-Vue.createApp({
+createApp({
     components: {
         'score-board': ScoreBoard,
         'scorer-controls': ScorerControls,

--- a/live.js
+++ b/live.js
@@ -17,15 +17,14 @@ function createEmptyLineup() {
     };
 }
 
-new Vue({
-    el: '#app',
+Vue.createApp({
     components: {
         'score-board': ScoreBoard,
         'scorer-controls': ScorerControls,
         'active-match-list': ActiveMatchList,
         'match-details': MatchDetails
     },
-    data: {
+    data() { return {
         idMatch: liveData.idMatch,
         isScorer: liveData.isScorer || false,
         canScore: liveData.canScore || false,
@@ -73,7 +72,7 @@ new Vue({
         retryTimer: null,
         isOnline: true,
         isSaving: false
-    },
+    }; },
     computed: {
         leftTeamKey() {
             return this.swapSides ? 'ext' : 'dom';
@@ -182,13 +181,13 @@ new Vue({
                 this.handleServiceAndRotation(team);
             }
             const key = 'score_' + team;
-            this.$set(this.score, key, (parseInt(this.score[key]) || 0) + 1);
+            this.score[key] = (parseInt(this.score[key]) || 0) + 1;
             this.markAsUnsaved();
         },
         decrementScore(team) {
             const key = 'score_' + team;
             const current = parseInt(this.score[key]) || 0;
-            this.$set(this.score, key, Math.max(0, current - 1));
+            this.score[key] = Math.max(0, current - 1);
             this.markAsUnsaved();
         },
         nextSet(winner) {
@@ -198,18 +197,18 @@ new Vue({
                 return;
             }
             // Save current set scores
-            this.$set(this.score, 'set_' + setNum + '_dom', this.score.score_dom);
-            this.$set(this.score, 'set_' + setNum + '_ext', this.score.score_ext);
+            this.score['set_' + setNum + '_dom'] = this.score.score_dom;
+            this.score['set_' + setNum + '_ext'] = this.score.score_ext;
             // Increment sets won
             if (winner === 'dom') {
-                this.$set(this.score, 'sets_dom', (parseInt(this.score.sets_dom) || 0) + 1);
+                this.score.sets_dom = (parseInt(this.score.sets_dom) || 0) + 1;
             } else if (winner === 'ext') {
-                this.$set(this.score, 'sets_ext', (parseInt(this.score.sets_ext) || 0) + 1);
+                this.score.sets_ext = (parseInt(this.score.sets_ext) || 0) + 1;
             }
             // Reset point scores and advance set
-            this.$set(this.score, 'score_dom', 0);
-            this.$set(this.score, 'score_ext', 0);
-            this.$set(this.score, 'set_en_cours', setNum + 1);
+            this.score.score_dom = 0;
+            this.score.score_ext = 0;
+            this.score.set_en_cours = setNum + 1;
             this.resetTimeouts();
             this.resetPositions();
             this.servingTeam = null;
@@ -239,7 +238,7 @@ new Vue({
                 5: current[6] || '',
                 6: current[1] || ''
             };
-            this.$set(this.lineups, team, rotated);
+            this.lineups[team] = rotated;
             this.persistToLocalStorage();
         },
         updatePosition(team, position, value) {
@@ -252,15 +251,15 @@ new Vue({
             }
             const sanitizedValue = (value || '').toString().trim().slice(0, 100);
             const updated = Object.assign({}, this.lineups[team], { [normalizedPosition]: sanitizedValue });
-            this.$set(this.lineups, team, updated);
+            this.lineups[team] = updated;
             this.persistToLocalStorage();
         },
         resetPositions() {
             if (!this.isRotationModeEnabled) {
                 return;
             }
-            this.$set(this.lineups, 'dom', createEmptyLineup());
-            this.$set(this.lineups, 'ext', createEmptyLineup());
+            this.lineups.dom = createEmptyLineup();
+            this.lineups.ext = createEmptyLineup();
             this.persistToLocalStorage();
         },
 
@@ -553,4 +552,4 @@ new Vue({
             }).showToast();
         }
     }
-});
+}).mount('#app');

--- a/live.php
+++ b/live.php
@@ -67,7 +67,7 @@ if ($id_match) {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <TITLE>Live Score<?php echo $match ? ' - ' . htmlspecialchars($match['code_match']) : ''; ?></TITLE>
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://cdn.jsdelivr.net/npm/daisyui@4.12.2/dist/full.min.css" rel="stylesheet" type="text/css"/>

--- a/live.php
+++ b/live.php
@@ -60,6 +60,7 @@ if ($id_match) {
         $error = $e->getMessage();
     }
 }
+require_once __DIR__ . '/helpers/vite.php';
 ?>
 <!DOCTYPE html>
 <HTML data-theme="cupcake" lang="fr">
@@ -67,15 +68,7 @@ if ($id_match) {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <TITLE>Live Score<?php echo $match ? ' - ' . htmlspecialchars($match['code_match']) : ''; ?></TITLE>
-    <script src="https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link href="https://cdn.jsdelivr.net/npm/daisyui@4.12.2/dist/full.min.css" rel="stylesheet" type="text/css"/>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.1/css/all.min.css"
-          integrity="sha512-MV7K8+y+gLIBoVD59lQIYicR65iaqukzvf/nwasF0nqhPay5w/9lJmVM2hMDcnK1OnMGCdVK+iQrJ7lzPJQd1w=="
-          crossorigin="anonymous" referrerpolicy="no-referrer"/>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css">
-    <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
+    <?= vite_asset('src/css/app.css') ?>
 </HEAD>
 <BODY>
 <div id="app" class="min-h-screen bg-base-200">
@@ -196,6 +189,6 @@ if ($id_match) {
         error: <?php echo json_encode($error); ?>
     };
 </script>
-<script src="/live.js" type="module"></script>
+<?= vite_asset('live.js') ?>
 </BODY>
 </HTML>

--- a/match.js
+++ b/match.js
@@ -1,8 +1,17 @@
-﻿import {onSuccess, onError} from "./toaster.js";
+﻿import { createApp } from 'vue';
+import axios from 'axios';
+import Toastify from 'toastify-js';
+import { Notyf } from 'notyf';
+import {onSuccess, onError} from "./toaster.js";
 import {genericSignMatch, genericSignSheet} from "./signer.js";
 import {canAskReport, canAcceptReport, canRefuseReport, canGiveReportDate, postReportAction} from "./utils/reportUtils.js";
 
-Vue.createApp({
+// Expose les libs en global pour les sous-composants qui les utilisent sans import
+window.axios = axios;
+window.Toastify = Toastify;
+window.Notyf = Notyf;
+
+createApp({
     data() { return {
         id_match: (new URLSearchParams(window.location.search)).get('id_match'),
         matchData: {},

--- a/match.js
+++ b/match.js
@@ -2,9 +2,8 @@
 import {genericSignMatch, genericSignSheet} from "./signer.js";
 import {canAskReport, canAcceptReport, canRefuseReport, canGiveReportDate, postReportAction} from "./utils/reportUtils.js";
 
-new Vue({
-    el: '#app',
-    data: {
+Vue.createApp({
+    data() { return {
         id_match: (new URLSearchParams(window.location.search)).get('id_match'),
         matchData: {},
         isLoading: false,
@@ -17,7 +16,7 @@ new Vue({
             comment: '',
             selectedDate: null,
         },
-    },
+    }; },
     mounted() {
         this.fetchUserDetails();
         this.reloadData();
@@ -252,4 +251,4 @@ new Vue({
                 .finally(() => { this.isLoading = false; });
         },
     }
-});
+}).mount('#app');

--- a/match.php
+++ b/match.php
@@ -28,6 +28,7 @@ try {
 }
 @session_start();
 $user_details = $_SESSION;
+require_once __DIR__ . '/helpers/vite.php';
 ?>
 <!DOCTYPE html>
 <HTML data-theme="cupcake" lang="fr">
@@ -35,21 +36,7 @@ $user_details = $_SESSION;
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <TITLE>Feuille de match</TITLE>
-    <!--TOASTER-->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css">
-    <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
-    <!--VUE-->
-    <script src="https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.js"></script>
-    <!--AXIOS-->
-    <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
-    <!-- TAILWIND-->
-    <script src="https://cdn.tailwindcss.com"></script>
-    <!--DAISYUI-->
-    <link href="https://cdn.jsdelivr.net/npm/daisyui@4.12.2/dist/full.min.css" rel="stylesheet" type="text/css"/>
-    <!--    FONT AWESOME-->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.1/css/all.min.css"
-          integrity="sha512-MV7K8+y+gLIBoVD59lQIYicR65iaqukzvf/nwasF0nqhPay5w/9lJmVM2hMDcnK1OnMGCdVK+iQrJ7lzPJQd1w=="
-          crossorigin="anonymous" referrerpolicy="no-referrer"/>
+    <?= vite_asset('src/css/app.css') ?>
 </HEAD>
 <BODY>
 <div id="app" class="max-w-3xl mx-auto p-6">
@@ -240,6 +227,6 @@ $user_details = $_SESSION;
         </dialog>
     </div>
 </div>
-<script src="/match.js" type="module"></script>
+<?= vite_asset('match.js') ?>
 </BODY>
 </HTML>

--- a/match.php
+++ b/match.php
@@ -39,7 +39,7 @@ $user_details = $_SESSION;
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css">
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
     <!--VUE-->
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.js"></script>
     <!--AXIOS-->
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
     <!-- TAILWIND-->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2880 @@
+{
+  "name": "ufolep13volley-frontend",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ufolep13volley-frontend",
+      "version": "0.1.0",
+      "dependencies": {
+        "@fortawesome/fontawesome-free": "^6.7.2",
+        "axios": "^1.7.9",
+        "brackets-viewer": "^1.6.4",
+        "notyf": "^3.10.0",
+        "toastify-js": "^1.12.0",
+        "vue": "^3.5.13",
+        "vue-router": "^4.5.0"
+      },
+      "devDependencies": {
+        "@vitejs/plugin-vue": "^5.2.1",
+        "autoprefixer": "^10.4.20",
+        "daisyui": "^4.12.22",
+        "postcss": "^8.4.49",
+        "tailwindcss": "^3.4.17",
+        "vite": "^5.4.11"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
+      "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.35.tgz",
+      "integrity": "sha512-BUmHaR1J+O+CKZ9uJucdVTEr1LHsdyvv7vG3eNRhK3CczEHeMd/LtsHAuD7PbrxvI2envCY2v7HI1vC1aBRzKw==",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@vue/shared": "3.5.35",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.35.tgz",
+      "integrity": "sha512-k+bprkXxuqhVajgTx5mUHuir7TwQzUKOWR40ng1ncAqQRPnrLngGGgqVEEhOnTMlc8btHYVKmrP8s5Qyg0hvYA==",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.35",
+        "@vue/shared": "3.5.35"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.35.tgz",
+      "integrity": "sha512-G5VPMcXTSywXBgtFOZOnHKBxKSrwXUcvY1iaF5/hRcy7t0J6CH/d8ha9F4nzi00Fax1eLV0QHM7v4mQu68jydw==",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@vue/compiler-core": "3.5.35",
+        "@vue/compiler-dom": "3.5.35",
+        "@vue/compiler-ssr": "3.5.35",
+        "@vue/shared": "3.5.35",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.15",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.35.tgz",
+      "integrity": "sha512-rGhAeXgdM7/ffTJGXT69rCCdTmjDewnFuUZfBQQHTdcEBeWdT5HCGY60y2ytLJr9/Dsu7IntUi5z/w0h6Rjnzw==",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.35",
+        "@vue/shared": "3.5.35"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g=="
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.35.tgz",
+      "integrity": "sha512-tVc+SsHConvh/Lz64qq1pP3rYArBmK42xonovEcxY74SQtvctZodG/zhq54P5dr38cVuw25d27cPNRdlMidpGQ==",
+      "dependencies": {
+        "@vue/shared": "3.5.35"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.35.tgz",
+      "integrity": "sha512-A/xFNX9loIcWDygeQuNCfKuh0CoYBzxhqEMNah5TSFg9Z53DrFYEN2qi5CU9necjM1OWYegYREUTHmXTmhfXtg==",
+      "dependencies": {
+        "@vue/reactivity": "3.5.35",
+        "@vue/shared": "3.5.35"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.35.tgz",
+      "integrity": "sha512-odrJ1C391dbGnyDRh8U+rnP7J2amIEzfmRk5vXy7xi3aZhEXofTvpi0T4HJb6jlNqQZTNPR5MPHSB3RHNkIORA==",
+      "dependencies": {
+        "@vue/reactivity": "3.5.35",
+        "@vue/runtime-core": "3.5.35",
+        "@vue/shared": "3.5.35",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.35.tgz",
+      "integrity": "sha512-NkebSOYdB97wi8OQcO3HqzZSlymJi/aWsN/7h74OSVhRTm6qGs3Jp3e0rCXynmWwSlKeRrnlIug+ilYoHBmQDA==",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.35",
+        "@vue/shared": "3.5.35"
+      },
+      "peerDependencies": {
+        "vue": "3.5.35"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.35.tgz",
+      "integrity": "sha512-zSbjL7gRXwks2ZQLRGCajBtBXEOXW9Ddhn/HvSdrGkE2dqGnumzW8XtusRrxrE9LvqtiqDXQ+A60Hp6mvdYxfA=="
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.32",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
+      "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
+      "dev": true,
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/brackets-manager": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/brackets-manager/-/brackets-manager-1.11.0.tgz",
+      "integrity": "sha512-IhjktPosZTgqPo73NIuQbCOEuF5y6eJFmXeK5M5pBmjwl2TCWBqVJBlwhYonTLxILAOtjJ3dUjSyte97VI4cIQ==",
+      "dependencies": {
+        "brackets-model": "^1.7.0",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/brackets-memory-db": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/brackets-memory-db/-/brackets-memory-db-1.0.6.tgz",
+      "integrity": "sha512-agCBS56rwbnZFwLhX3WGbFusAwvyuYz39MG7YrX+e+P3VK9VS/z3mjiZGM4XCYPL5Z6tGWcJ1BTnhYh7ww9t7w==",
+      "dependencies": {
+        "rfdc": "^1.3.0"
+      },
+      "peerDependencies": {
+        "brackets-model": "^1.7.0"
+      }
+    },
+    "node_modules/brackets-model": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/brackets-model/-/brackets-model-1.7.0.tgz",
+      "integrity": "sha512-Hj6WpXjWw/VmCha3LOSYC1ZjHPXD2UahwPVOEEboBmxFP8CfTdnm4kDUyG23RfTH+ktoNPrmcxNnHUN/T5IwLg=="
+    },
+    "node_modules/brackets-viewer": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/brackets-viewer/-/brackets-viewer-1.9.1.tgz",
+      "integrity": "sha512-+B29mJBsc2G4yWGQAve4HukmETQgm27TshwOKaXJfl3zCKO5yji+fLQdP1/bSWB0LulF9QzBKGPsiWYU8NYcow==",
+      "dependencies": {
+        "brackets-manager": "^1.11.0",
+        "brackets-memory-db": "^1.0.6",
+        "brackets-model": "^1.7.0",
+        "i18next": "^21.6.14",
+        "i18next-browser-languagedetector": "^6.1.4",
+        "path-browserify": "^1.0.1",
+        "process": "^0.11.10",
+        "util": "^0.12.4"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/css-selector-tokenizer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.8.0.tgz",
+      "integrity": "sha512-Jd6Ig3/pe62/qe5SBPTN8h8LeUg/pT4lLgtavPf7updwwHpvFzxvOQBHYj2LZDMjUnBzgvIUSjRcf6oT5HzHFg==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "fastparse": "^1.1.2"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
+    },
+    "node_modules/culori": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/culori/-/culori-3.3.0.tgz",
+      "integrity": "sha512-pHJg+jbuFsCjz9iclQBqyL3B2HLCBF71BwVNujUYEvCeQMvV97R59MNK3R2+jgJ3a1fcZgI9B3vYgz8lzr/BFQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/daisyui": {
+      "version": "4.12.24",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-4.12.24.tgz",
+      "integrity": "sha512-JYg9fhQHOfXyLadrBrEqCDM6D5dWCSSiM6eTNCRrBRzx/VlOCrLS8eDfIw9RVvs64v2mJdLooKXY8EwQzoszAA==",
+      "dev": true,
+      "dependencies": {
+        "css-selector-tokenizer": "^0.8",
+        "culori": "^3",
+        "picocolors": "^1",
+        "postcss-js": "^4"
+      },
+      "engines": {
+        "node": ">=16.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/daisyui"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.362",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.362.tgz",
+      "integrity": "sha512-PUY2DrLvkjkUuWqq+KPL2iWshrJsZOcIojzRQ7eXFacc9dWga7MGMJAa15VbiejSZB1PAXaRLAiKgruHP8LB1w==",
+      "dev": true
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fastparse": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
+      "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
+      "dev": true
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "21.10.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.10.0.tgz",
+      "integrity": "sha512-YeuIBmFsGjUfO3qBmMOc0rQaun4mIpGKET5WDwvu8lU7gvwpcariZLNtL0Fzj+zazcHUrlXHiptcFhBMFaxzfg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "dependencies": {
+        "@babel/runtime": "^7.17.2"
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "6.1.8",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-6.1.8.tgz",
+      "integrity": "sha512-Svm+MduCElO0Meqpj1kJAriTC6OhI41VhlT/A0UPjGoPZBhAHIaGE5EfsHlTpgdH09UVX7rcc72pSDDBeKSQQA==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
+      "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/notyf": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/notyf/-/notyf-3.10.0.tgz",
+      "integrity": "sha512-Mtnp+0qiZxgrH+TzVlzhWyZceHdAZ/UWK0/ju9U0HQeDpap1mZ8cC7H5wSI5mwgni6yeAjaxsTw0sbMK+aSuHw=="
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toastify-js": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/toastify-js/-/toastify-js-1.12.0.tgz",
+      "integrity": "sha512-HeMHCO9yLPvP9k0apGSdPUWrUbLnxUKNFzgUoZp1PHCLploIX/4DSQ7V8H25ef+h4iO9n0he7ImfcndnN6nDrQ=="
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.35.tgz",
+      "integrity": "sha512-cx89fnr+0kVGHiNFG6y6s0bdjypJRFNZn6x3WPstNdQR1bi1mbB7h4v5IBGTsPJU3nK1+0Iqj3Zf+hZWMieR4Q==",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.35",
+        "@vue/compiler-sfc": "3.5.35",
+        "@vue/runtime-dom": "3.5.35",
+        "@vue/server-renderer": "3.5.35",
+        "@vue/shared": "3.5.35"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
+      "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.21.tgz",
+      "integrity": "sha512-zbRA8cVm6io/d5W8uIe2hblzN76/Wm3v/yiythQvr+dpBWeqhPSWIDNj4zOyHi4zKbMK6DN34Xsr9jPHJERAEw==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "ufolep13volley-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Frontend bundle (Vite + Vue 3) pour ufolep13volley",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.2.1",
+    "autoprefixer": "^10.4.20",
+    "daisyui": "^4.12.22",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.17",
+    "vite": "^5.4.11"
+  },
+  "dependencies": {
+    "@fortawesome/fontawesome-free": "^6.7.2",
+    "axios": "^1.7.9",
+    "brackets-viewer": "^1.6.4",
+    "notyf": "^3.10.0",
+    "toastify-js": "^1.12.0",
+    "vue": "^3.5.13",
+    "vue-router": "^4.5.0"
+  }
+}

--- a/pages/components/layout/AppLayout.js
+++ b/pages/components/layout/AppLayout.js
@@ -92,8 +92,8 @@ const router = VueRouter.createRouter({
 
 export default {
     components: {
-        'main-navbar': () => import('../navbar/Main.js'),
-        'main-footer': () => import('../footer/Main.js'),
+        'main-navbar': Vue.defineAsyncComponent(() => import('../navbar/Main.js')),
+        'main-footer': Vue.defineAsyncComponent(() => import('../footer/Main.js')),
     },
     router,
     template: `

--- a/pages/components/layout/AppLayout.js
+++ b/pages/components/layout/AppLayout.js
@@ -81,12 +81,12 @@ const routes = [
         component: () => import('../panel/FinalsDrawAdmin.js'),
     },
 
-    {path: '*', redirect: '/home'}
+    {path: '/:pathMatch(.*)*', redirect: '/home'}
 
 ];
 
-const router = new VueRouter({
-    mode: 'hash',
+const router = VueRouter.createRouter({
+    history: VueRouter.createWebHashHistory(),
     routes
 });
 

--- a/pages/components/layout/AppLayout.js
+++ b/pages/components/layout/AppLayout.js
@@ -1,3 +1,6 @@
+import { defineAsyncComponent } from 'vue';
+import { createRouter, createWebHashHistory } from 'vue-router';
+
 const routes = [
     // Routes pour my_page
     {
@@ -85,15 +88,15 @@ const routes = [
 
 ];
 
-const router = VueRouter.createRouter({
-    history: VueRouter.createWebHashHistory(),
+const router = createRouter({
+    history: createWebHashHistory(),
     routes
 });
 
 export default {
     components: {
-        'main-navbar': Vue.defineAsyncComponent(() => import('../navbar/Main.js')),
-        'main-footer': Vue.defineAsyncComponent(() => import('../footer/Main.js')),
+        'main-navbar': defineAsyncComponent(() => import('../navbar/Main.js')),
+        'main-footer': defineAsyncComponent(() => import('../footer/Main.js')),
     },
     router,
     template: `

--- a/pages/components/layout/TeamLeaderLayout.js
+++ b/pages/components/layout/TeamLeaderLayout.js
@@ -60,12 +60,12 @@ const routes = [
         path: '/messages',
         component: () => import('../panel/TeamLeaderMessages.js')
     },
-    {path: '*', redirect: '/dashboard'}
+    {path: '/:pathMatch(.*)*', redirect: '/dashboard'}
 ];
 
 // Configuration du router
-const router = new VueRouter({
-    mode: 'hash',
+const router = VueRouter.createRouter({
+    history: VueRouter.createWebHashHistory(),
     routes
 });
 

--- a/pages/components/layout/TeamLeaderLayout.js
+++ b/pages/components/layout/TeamLeaderLayout.js
@@ -71,7 +71,7 @@ const router = VueRouter.createRouter({
 
 export default {
     components: {
-        'team-leader-navbar': () => import('../navbar/TeamLeader.js')
+        'team-leader-navbar': Vue.defineAsyncComponent(() => import('../navbar/TeamLeader.js'))
     },
     router,
     data() {

--- a/pages/components/layout/TeamLeaderLayout.js
+++ b/pages/components/layout/TeamLeaderLayout.js
@@ -1,3 +1,6 @@
+import { defineAsyncComponent } from 'vue';
+import { createRouter, createWebHashHistory } from 'vue-router';
+
 // Fonction utilitaire pour vérifier l'authentification côté client
 async function checkAuthentication() {
     try {
@@ -64,14 +67,14 @@ const routes = [
 ];
 
 // Configuration du router
-const router = VueRouter.createRouter({
-    history: VueRouter.createWebHashHistory(),
+const router = createRouter({
+    history: createWebHashHistory(),
     routes
 });
 
 export default {
     components: {
-        'team-leader-navbar': Vue.defineAsyncComponent(() => import('../navbar/TeamLeader.js'))
+        'team-leader-navbar': defineAsyncComponent(() => import('../navbar/TeamLeader.js'))
     },
     router,
     data() {

--- a/pages/components/list/Matchs.js
+++ b/pages/components/list/Matchs.js
@@ -1,10 +1,11 @@
+import { defineAsyncComponent } from 'vue';
 import {canAskReport, canAcceptReport, canRefuseReport, canGiveReportDate, postReportAction} from "/utils/reportUtils.js";
 import {matchFilterMixin} from "/utils/matchFilterMixin.js";
 
 export default {
     mixins: [matchFilterMixin],
     components: {
-        'match-card': Vue.defineAsyncComponent(() => import('../card/Match.js'))
+        'match-card': defineAsyncComponent(() => import('../card/Match.js'))
     }, template: `
     <div>
       <div class="flex flex-wrap gap-4 m-2">

--- a/pages/components/list/Matchs.js
+++ b/pages/components/list/Matchs.js
@@ -4,7 +4,7 @@ import {matchFilterMixin} from "/utils/matchFilterMixin.js";
 export default {
     mixins: [matchFilterMixin],
     components: {
-        'match-card': () => import('../card/Match.js')
+        'match-card': Vue.defineAsyncComponent(() => import('../card/Match.js'))
     }, template: `
     <div>
       <div class="flex flex-wrap gap-4 m-2">

--- a/pages/components/panel/CupDrawAdmin.js
+++ b/pages/components/panel/CupDrawAdmin.js
@@ -289,14 +289,14 @@ export default {
             // Ensure all pool indices exist
             for (let i = 1; i <= this.nbPools; i++) {
                 if (!this.pools[i]) {
-                    this.$set(this.pools, i, []);
+                    this.pools[i] = [];
                 }
             }
             // Remove pools beyond nbPools
             Object.keys(this.pools).forEach(key => {
                 if (parseInt(key) > this.nbPools) {
                     // Move teams back to available
-                    this.$delete(this.pools, key);
+                    delete this.pools[key];
                 }
             });
         },
@@ -347,20 +347,19 @@ export default {
             
             // Remove from previous pool if coming from one
             if (this.draggedFromPool) {
-                this.$set(this.pools, this.draggedFromPool, this.pools[this.draggedFromPool].filter(
+                this.pools[this.draggedFromPool] = this.pools[this.draggedFromPool].filter(
                     t => t.id_equipe !== this.draggedTeam.id_equipe
-                ));
+                );
             }
-            
+
             // Add to new pool
             if (!this.pools[poolIndex]) {
-                this.$set(this.pools, poolIndex, []);
+                this.pools[poolIndex] = [];
             }
-            
+
             // Check if team already in this pool
             if (!this.pools[poolIndex].find(t => t.id_equipe === this.draggedTeam.id_equipe)) {
-                const newPool = [...this.pools[poolIndex], this.draggedTeam];
-                this.$set(this.pools, poolIndex, newPool);
+                this.pools[poolIndex] = [...this.pools[poolIndex], this.draggedTeam];
             }
             
             this.hasChanges = true;
@@ -373,25 +372,25 @@ export default {
             if (!this.draggedTeam || !this.draggedFromPool) return;
             
             // Remove from pool
-            this.$set(this.pools, this.draggedFromPool, this.pools[this.draggedFromPool].filter(
+            this.pools[this.draggedFromPool] = this.pools[this.draggedFromPool].filter(
                 t => t.id_equipe !== this.draggedTeam.id_equipe
-            ));
+            );
             
             this.hasChanges = true;
             this.draggedTeam = null;
             this.draggedFromPool = null;
         },
         removeFromPool(poolIndex, team) {
-            this.$set(this.pools, poolIndex, this.pools[poolIndex].filter(
+            this.pools[poolIndex] = this.pools[poolIndex].filter(
                 t => t.id_equipe !== team.id_equipe
-            ));
+            );
             this.hasChanges = true;
         },
         clearAllPools() {
             if (!confirm('Êtes-vous sûr de vouloir vider toutes les poules ?')) return;
-            
+
             Object.keys(this.pools).forEach(key => {
-                this.$set(this.pools, key, []);
+                this.pools[key] = [];
             });
             this.hasChanges = true;
         },

--- a/pages/components/panel/Division.js
+++ b/pages/components/panel/Division.js
@@ -1,10 +1,12 @@
+import { defineAsyncComponent } from 'vue';
+
 export default {
     components: {
-        'limit-date-navbar': Vue.defineAsyncComponent(() => import('../navbar/LimitDate.js')),
-        'commission-member': Vue.defineAsyncComponent(() => import('../navbar/CommissionMember.js')),
-        'rank-table': Vue.defineAsyncComponent(() => import('../table/Rank.js')),
-        'matchs-table': Vue.defineAsyncComponent(() => import('../table/Matchs.js')),
-        'to-schedule-matchs-table': Vue.defineAsyncComponent(() => import('../table/ToScheduleMatchs.js')),
+        'limit-date-navbar': defineAsyncComponent(() => import('../navbar/LimitDate.js')),
+        'commission-member': defineAsyncComponent(() => import('../navbar/CommissionMember.js')),
+        'rank-table': defineAsyncComponent(() => import('../table/Rank.js')),
+        'matchs-table': defineAsyncComponent(() => import('../table/Matchs.js')),
+        'to-schedule-matchs-table': defineAsyncComponent(() => import('../table/ToScheduleMatchs.js')),
     },
     template: `
       <div>

--- a/pages/components/panel/Division.js
+++ b/pages/components/panel/Division.js
@@ -1,10 +1,10 @@
 export default {
     components: {
-        'limit-date-navbar': () => import('../navbar/LimitDate.js'),
-        'commission-member': () => import('../navbar/CommissionMember.js'),
-        'rank-table': () => import('../table/Rank.js'),
-        'matchs-table': () => import('../table/Matchs.js'),
-        'to-schedule-matchs-table': () => import('../table/ToScheduleMatchs.js'),
+        'limit-date-navbar': Vue.defineAsyncComponent(() => import('../navbar/LimitDate.js')),
+        'commission-member': Vue.defineAsyncComponent(() => import('../navbar/CommissionMember.js')),
+        'rank-table': Vue.defineAsyncComponent(() => import('../table/Rank.js')),
+        'matchs-table': Vue.defineAsyncComponent(() => import('../table/Matchs.js')),
+        'to-schedule-matchs-table': Vue.defineAsyncComponent(() => import('../table/ToScheduleMatchs.js')),
     },
     template: `
       <div>

--- a/pages/components/panel/Finals.js
+++ b/pages/components/panel/Finals.js
@@ -1,9 +1,9 @@
 export default {
     components: {
-        'limit-date-navbar': () => import('../navbar/LimitDate.js'),
-        'commission-member': () => import('../navbar/CommissionMember.js'),
-        'matchs-list': () => import('../list/Matchs.js'),
-        'tournament-bracket-viewer': () => import('./TournamentBracketViewer.js'),
+        'limit-date-navbar': Vue.defineAsyncComponent(() => import('../navbar/LimitDate.js')),
+        'commission-member': Vue.defineAsyncComponent(() => import('../navbar/CommissionMember.js')),
+        'matchs-list': Vue.defineAsyncComponent(() => import('../list/Matchs.js')),
+        'tournament-bracket-viewer': Vue.defineAsyncComponent(() => import('./TournamentBracketViewer.js')),
     },
     template: `
       <div>

--- a/pages/components/panel/Finals.js
+++ b/pages/components/panel/Finals.js
@@ -1,9 +1,11 @@
+import { defineAsyncComponent } from 'vue';
+
 export default {
     components: {
-        'limit-date-navbar': Vue.defineAsyncComponent(() => import('../navbar/LimitDate.js')),
-        'commission-member': Vue.defineAsyncComponent(() => import('../navbar/CommissionMember.js')),
-        'matchs-list': Vue.defineAsyncComponent(() => import('../list/Matchs.js')),
-        'tournament-bracket-viewer': Vue.defineAsyncComponent(() => import('./TournamentBracketViewer.js')),
+        'limit-date-navbar': defineAsyncComponent(() => import('../navbar/LimitDate.js')),
+        'commission-member': defineAsyncComponent(() => import('../navbar/CommissionMember.js')),
+        'matchs-list': defineAsyncComponent(() => import('../list/Matchs.js')),
+        'tournament-bracket-viewer': defineAsyncComponent(() => import('./TournamentBracketViewer.js')),
     },
     template: `
       <div>

--- a/pages/components/panel/HallOfFame.js
+++ b/pages/components/panel/HallOfFame.js
@@ -1,6 +1,6 @@
 export default {
     components: {
-        'hall-of-fame-table': () => import('../table/HallOfFame.js'),
+        'hall-of-fame-table': Vue.defineAsyncComponent(() => import('../table/HallOfFame.js')),
     },
     template: `
       <hall-of-fame-table :key="hall-of-fame"></hall-of-fame-table>

--- a/pages/components/panel/HallOfFame.js
+++ b/pages/components/panel/HallOfFame.js
@@ -1,6 +1,8 @@
+import { defineAsyncComponent } from 'vue';
+
 export default {
     components: {
-        'hall-of-fame-table': Vue.defineAsyncComponent(() => import('../table/HallOfFame.js')),
+        'hall-of-fame-table': defineAsyncComponent(() => import('../table/HallOfFame.js')),
     },
     template: `
       <hall-of-fame-table :key="hall-of-fame"></hall-of-fame-table>

--- a/pages/components/panel/Home.js
+++ b/pages/components/panel/Home.js
@@ -1,8 +1,8 @@
 export default {
     components: {
-        'news': () => import('../table/News.js'),
-        'photos': () => import('../carousel/Photos.js'),
-        'annual-calendar': () => import('../calendar/AnnualCalendar.js'),
+        'news': Vue.defineAsyncComponent(() => import('../table/News.js')),
+        'photos': Vue.defineAsyncComponent(() => import('../carousel/Photos.js')),
+        'annual-calendar': Vue.defineAsyncComponent(() => import('../calendar/AnnualCalendar.js')),
     },
     template: `
       <div class="flex flex-col items-center gap-8">

--- a/pages/components/panel/Home.js
+++ b/pages/components/panel/Home.js
@@ -1,8 +1,10 @@
+import { defineAsyncComponent } from 'vue';
+
 export default {
     components: {
-        'news': Vue.defineAsyncComponent(() => import('../table/News.js')),
-        'photos': Vue.defineAsyncComponent(() => import('../carousel/Photos.js')),
-        'annual-calendar': Vue.defineAsyncComponent(() => import('../calendar/AnnualCalendar.js')),
+        'news': defineAsyncComponent(() => import('../table/News.js')),
+        'photos': defineAsyncComponent(() => import('../carousel/Photos.js')),
+        'annual-calendar': defineAsyncComponent(() => import('../calendar/AnnualCalendar.js')),
     },
     template: `
       <div class="flex flex-col items-center gap-8">

--- a/pages/components/panel/LastResults.js
+++ b/pages/components/panel/LastResults.js
@@ -1,6 +1,8 @@
+import { defineAsyncComponent } from 'vue';
+
 export default {
     components: {
-        'matchs-table': Vue.defineAsyncComponent(() => import('../table/Matchs.js')),
+        'matchs-table': defineAsyncComponent(() => import('../table/Matchs.js')),
     },
     template: `
         <matchs-table :key="last-results" :fetch-url="matchesFetchUrl"></matchs-table>

--- a/pages/components/panel/LastResults.js
+++ b/pages/components/panel/LastResults.js
@@ -1,6 +1,6 @@
 export default {
     components: {
-        'matchs-table': () => import('../table/Matchs.js'),
+        'matchs-table': Vue.defineAsyncComponent(() => import('../table/Matchs.js')),
     },
     template: `
         <matchs-table :key="last-results" :fetch-url="matchesFetchUrl"></matchs-table>

--- a/pages/components/panel/TeamLeaderDashboard.js
+++ b/pages/components/panel/TeamLeaderDashboard.js
@@ -1,7 +1,9 @@
+import { defineAsyncComponent } from 'vue';
+
 export default {
     components: {
-        'team-leader-infos': Vue.defineAsyncComponent(() => import('./TeamLeaderInfos.js')),
-        'team-leader-alerts': Vue.defineAsyncComponent(() => import('./TeamLeaderAlerts.js'))
+        'team-leader-infos': defineAsyncComponent(() => import('./TeamLeaderInfos.js')),
+        'team-leader-alerts': defineAsyncComponent(() => import('./TeamLeaderAlerts.js'))
     },
     template: `
       <div>

--- a/pages/components/panel/TeamLeaderDashboard.js
+++ b/pages/components/panel/TeamLeaderDashboard.js
@@ -1,7 +1,7 @@
 export default {
     components: {
-        'team-leader-infos': () => import('./TeamLeaderInfos.js'),
-        'team-leader-alerts': () => import('./TeamLeaderAlerts.js')
+        'team-leader-infos': Vue.defineAsyncComponent(() => import('./TeamLeaderInfos.js')),
+        'team-leader-alerts': Vue.defineAsyncComponent(() => import('./TeamLeaderAlerts.js'))
     },
     template: `
       <div>

--- a/pages/components/panel/WeekMatchs.js
+++ b/pages/components/panel/WeekMatchs.js
@@ -1,6 +1,8 @@
+import { defineAsyncComponent } from 'vue';
+
 export default {
     components: {
-        'matchs-table': Vue.defineAsyncComponent(() => import('../table/Matchs.js')),
+        'matchs-table': defineAsyncComponent(() => import('../table/Matchs.js')),
     },
     template: `
         <matchs-table :key="week-matchs" :fetch-url="matchesFetchUrl"></matchs-table>

--- a/pages/components/panel/WeekMatchs.js
+++ b/pages/components/panel/WeekMatchs.js
@@ -1,6 +1,6 @@
 export default {
     components: {
-        'matchs-table': () => import('../table/Matchs.js'),
+        'matchs-table': Vue.defineAsyncComponent(() => import('../table/Matchs.js')),
     },
     template: `
         <matchs-table :key="week-matchs" :fetch-url="matchesFetchUrl"></matchs-table>

--- a/pages/home.html
+++ b/pages/home.html
@@ -7,8 +7,8 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/daisyui@4.12.22/dist/full.css">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/vue@2/dist/vue.js"></script>
-    <script src="https://unpkg.com/vue-router@3.5.4/dist/vue-router.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.js"></script>
+    <script src="https://unpkg.com/vue-router@4/dist/vue-router.global.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/notyf@3/notyf.min.css">
     <script src="https://cdn.jsdelivr.net/npm/notyf@3/notyf.min.js"></script>

--- a/pages/home.html
+++ b/pages/home.html
@@ -4,17 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>UFOLEP 13 Volley</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/daisyui@4.12.22/dist/full.css">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.js"></script>
-    <script src="https://unpkg.com/vue-router@4/dist/vue-router.global.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/notyf@3/notyf.min.css">
-    <script src="https://cdn.jsdelivr.net/npm/notyf@3/notyf.min.js"></script>
+    <link rel="stylesheet" href="../src/css/app.css">
 </head>
 <body class="bg-base-100">
 <div id="app"></div>
-<script src="/pages/home.js" type="module"></script>
+<script src="./home.js" type="module"></script>
 </body>
 </html>

--- a/pages/home.js
+++ b/pages/home.js
@@ -1,7 +1,16 @@
 // Import du layout pour les pages team leader
+import { createApp } from 'vue';
+import axios from 'axios';
+import Toastify from 'toastify-js';
+import { Notyf } from 'notyf';
 import AppLayout from './components/layout/AppLayout.js';
 
+// Expose les libs en global pour les sous-composants qui les utilisent sans import
+window.axios = axios;
+window.Toastify = Toastify;
+window.Notyf = Notyf;
+
 // Montage de l'application Vue
-const app = Vue.createApp(AppLayout);
+const app = createApp(AppLayout);
 app.use(AppLayout.router);
 app.mount('#app');

--- a/pages/home.js
+++ b/pages/home.js
@@ -2,7 +2,6 @@
 import AppLayout from './components/layout/AppLayout.js';
 
 // Montage de l'application Vue
-new Vue({
-    el: '#app',
-    render: h => h(AppLayout)
-});
+const app = Vue.createApp(AppLayout);
+app.use(AppLayout.router);
+app.mount('#app');

--- a/pages/my_page.html
+++ b/pages/my_page.html
@@ -7,8 +7,8 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/daisyui@4.12.22/dist/full.css">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/vue@2/dist/vue.js"></script>
-    <script src="https://unpkg.com/vue-router@3.5.4/dist/vue-router.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.js"></script>
+    <script src="https://unpkg.com/vue-router@4/dist/vue-router.global.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/notyf@3/notyf.min.css">
     <script src="https://cdn.jsdelivr.net/npm/notyf@3/notyf.min.js"></script>

--- a/pages/my_page.html
+++ b/pages/my_page.html
@@ -4,17 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Ma page d'accueil - UFOLEP 13 Volley</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/daisyui@4.12.22/dist/full.css">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.js"></script>
-    <script src="https://unpkg.com/vue-router@4/dist/vue-router.global.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/notyf@3/notyf.min.css">
-    <script src="https://cdn.jsdelivr.net/npm/notyf@3/notyf.min.js"></script>
+    <link rel="stylesheet" href="../src/css/app.css">
 </head>
 <body class="bg-base-100">
-    <div id="app"></div>
-    <script src="/pages/my_page.js" type="module"></script>
+<div id="app"></div>
+<script src="./my_page.js" type="module"></script>
 </body>
 </html>

--- a/pages/my_page.js
+++ b/pages/my_page.js
@@ -1,7 +1,15 @@
 // Import du layout pour les pages team leader
+import { createApp } from 'vue';
+import axios from 'axios';
+import Toastify from 'toastify-js';
+import { Notyf } from 'notyf';
 import TeamLeaderLayout from './components/layout/TeamLeaderLayout.js';
 
+window.axios = axios;
+window.Toastify = Toastify;
+window.Notyf = Notyf;
+
 // Montage de l'application Vue
-const app = Vue.createApp(TeamLeaderLayout);
+const app = createApp(TeamLeaderLayout);
 app.use(TeamLeaderLayout.router);
 app.mount('#app');

--- a/pages/my_page.js
+++ b/pages/my_page.js
@@ -2,7 +2,6 @@
 import TeamLeaderLayout from './components/layout/TeamLeaderLayout.js';
 
 // Montage de l'application Vue
-new Vue({
-  el: '#app',
-  render: h => h(TeamLeaderLayout)
-});
+const app = Vue.createApp(TeamLeaderLayout);
+app.use(TeamLeaderLayout.router);
+app.mount('#app');

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+    plugins: {
+        tailwindcss: {},
+        autoprefixer: {},
+    },
+};

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -1,0 +1,22 @@
+/*
+ * Feuille CSS globale du frontend bundlé.
+ *
+ * Contient :
+ *   - Les CSS des libs tierces qu'on chargeait avant par CDN
+ *   - Tailwind (base / components / utilities) avec DaisyUI en plugin
+ *
+ * Référencée comme entrée Vite à part (`css/app`) ; le helper PHP vite_asset()
+ * l'inclura dans le <head> de chaque page convertie.
+ *
+ * IMPORTANT : tous les @import DOIVENT précéder les @tailwind (règle CSS :
+ * "@import must precede all other statements").
+ */
+
+/* Libs tierces (auparavant chargées par CDN) */
+@import '@fortawesome/fontawesome-free/css/all.min.css';
+@import 'notyf/notyf.min.css';
+@import 'toastify-js/src/toastify.css';
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/survey.js
+++ b/survey.js
@@ -1,13 +1,12 @@
 import {onError, onSuccess} from "./toaster.js";
 import {genericSignMatch, genericSignSheet} from "./signer.js";
 
-new Vue({
-    el: '#app',
-    data: {
+Vue.createApp({
+    data() { return {
         matchData: {},
         surveyData: {},
         isLoading: false,
-    },
+    }; },
     mounted() {
         this.reloadData()
     },
@@ -70,4 +69,4 @@ new Vue({
                 });
         }
     }
-});
+}).mount('#app');

--- a/survey.js
+++ b/survey.js
@@ -1,7 +1,15 @@
+import { createApp } from 'vue';
+import axios from 'axios';
+import Toastify from 'toastify-js';
+import { Notyf } from 'notyf';
 import {onError, onSuccess} from "./toaster.js";
 import {genericSignMatch, genericSignSheet} from "./signer.js";
 
-Vue.createApp({
+window.axios = axios;
+window.Toastify = Toastify;
+window.Notyf = Notyf;
+
+createApp({
     data() { return {
         matchData: {},
         surveyData: {},

--- a/survey.php
+++ b/survey.php
@@ -25,6 +25,7 @@ try {
 }
 @session_start();
 $user_details = $_SESSION;
+require_once __DIR__ . '/helpers/vite.php';
 ?>
 <!DOCTYPE html>
 <HTML data-theme="cupcake" lang="fr">
@@ -32,21 +33,7 @@ $user_details = $_SESSION;
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sondage</title>
-    <!--TOASTER-->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css">
-    <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
-    <!--VUE-->
-    <script src="https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.js"></script>
-    <!--AXIOS-->
-    <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
-    <!-- TAILWIND-->
-    <script src="https://cdn.tailwindcss.com"></script>
-    <!--DAISYUI-->
-    <link href="https://cdn.jsdelivr.net/npm/daisyui@4.12.2/dist/full.min.css" rel="stylesheet" type="text/css"/>
-    <!--    FONT AWESOME-->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.1/css/all.min.css"
-          integrity="sha512-MV7K8+y+gLIBoVD59lQIYicR65iaqukzvf/nwasF0nqhPay5w/9lJmVM2hMDcnK1OnMGCdVK+iQrJ7lzPJQd1w=="
-          crossorigin="anonymous" referrerpolicy="no-referrer"/>
+    <?= vite_asset('src/css/app.css') ?>
     <script type="text/javascript">
         var id_match = <?php echo $id_match; ?>;
         var user_details = <?php echo json_encode($user_details); ?>;
@@ -153,6 +140,6 @@ $user_details = $_SESSION;
         </div>
     </form>
 </div>
-<script src="/survey.js" type="module"></script>
+<?= vite_asset('survey.js') ?>
 </BODY>
 </HTML>

--- a/survey.php
+++ b/survey.php
@@ -36,7 +36,7 @@ $user_details = $_SESSION;
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css">
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
     <!--VUE-->
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.js"></script>
     <!--AXIOS-->
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
     <!-- TAILWIND-->

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,21 @@
+/** @type {import('tailwindcss').Config} */
+import daisyui from 'daisyui';
+
+export default {
+    content: [
+        './pages/**/*.{js,html,php}',
+        './admin/**/*.{js,html,php}',
+        './src/**/*.{js,css,vue}',
+        './*.{php,html,js}',
+    ],
+    theme: {
+        extend: {},
+    },
+    plugins: [daisyui],
+    daisyui: {
+        // On laisse les thèmes par défaut. Les pages utilisent `data-theme="light"`
+        // et `data-theme="cupcake"` — les deux font partie des thèmes intégrés.
+        themes: ['light', 'cupcake'],
+        logs: false,
+    },
+};

--- a/team_sheets.js
+++ b/team_sheets.js
@@ -2,11 +2,19 @@ import {onSuccess, onError} from "./toaster.js";
 import {genericSignMatch, genericSignSheet} from "./signer.js";
 
 
-Vue.component('player-list', {
-    props: ['players', 'teamName', 'isSigned'],
+const PlayerList = {
+    props: {
+        players: {type: Array, required: true},
+        teamName: {type: String, default: ''},
+        isSigned: {type: Boolean, default: false},
+        // 'add' : bouton vert "+" qui emet add-player
+        // 'remove' : bouton rouge "poubelle" qui emet remove-player
+        mode: {type: String, default: 'add'},
+    },
+    emits: ['add-player', 'remove-player'],
     methods: {
         handleClick(player) {
-            this.$emit(this.$listeners['add-player'] ? 'add-player' : 'remove-player', player);
+            this.$emit(this.mode === 'add' ? 'add-player' : 'remove-player', player);
         },
         parseDate(dateString) {
             if (!dateString) {
@@ -39,19 +47,21 @@ Vue.component('player-list', {
               class="text-sm text-red-500 ml-2">(Non homologué le jour du match)</span>
           <button v-if="!isSigned"
                   class="btn ml-auto"
-                  :class="{'btn-success': $listeners['add-player'], 'btn-error': $listeners['remove-player']}"
+                  :class="{'btn-success': mode === 'add', 'btn-error': mode === 'remove'}"
                   @click="handleClick(player)">
             <i class="fa-solid"
-               :class="{'fa-plus': $listeners['add-player'], 'fa-trash': $listeners['remove-player']}"></i>
+               :class="{'fa-plus': mode === 'add', 'fa-trash': mode === 'remove'}"></i>
           </button>
         </div>
       </div>
     `
-});
+};
 
-new Vue({
-    el: '#app',
-    data: {
+Vue.createApp({
+    components: {
+        'player-list': PlayerList,
+    },
+    data() { return {
         id_match: (new URLSearchParams(window.location.search)).get('id_match'),
         matchData: {},
         availablePlayers: [],
@@ -59,7 +69,7 @@ new Vue({
         isLoading: false,
         query: '',
         renforts: [],
-    },
+    }; },
     computed: {
         availablePlayersDom() {
             return this.availablePlayers.filter(player => player.equipe === this.matchData.equipe_dom && !this.matchPlayers.includes(player));
@@ -152,4 +162,4 @@ new Vue({
                 });
         },
     }
-});
+}).mount('#app');

--- a/team_sheets.js
+++ b/team_sheets.js
@@ -1,5 +1,13 @@
+import { createApp } from 'vue';
+import axios from 'axios';
+import Toastify from 'toastify-js';
+import { Notyf } from 'notyf';
 import {onSuccess, onError} from "./toaster.js";
 import {genericSignMatch, genericSignSheet} from "./signer.js";
+
+window.axios = axios;
+window.Toastify = Toastify;
+window.Notyf = Notyf;
 
 
 const PlayerList = {
@@ -57,7 +65,7 @@ const PlayerList = {
     `
 };
 
-Vue.createApp({
+createApp({
     components: {
         'player-list': PlayerList,
     },

--- a/team_sheets.php
+++ b/team_sheets.php
@@ -32,7 +32,7 @@ $user_details = $_SESSION;
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css">
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
     <!--VUE-->
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.js"></script>
     <!--AXIOS-->
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
     <!-- TAILWIND-->
@@ -60,6 +60,7 @@ $user_details = $_SESSION;
                             :players="availablePlayersDom"
                             :team-name="matchData.equipe_dom"
                             :is-signed="matchData.is_sign_team_dom === 1 && matchData.is_sign_team_ext === 1"
+                            mode="add"
                             @add-player="addPlayer">
                     </player-list>
 
@@ -67,6 +68,7 @@ $user_details = $_SESSION;
                             :players="availablePlayersExt"
                             :team-name="matchData.equipe_ext"
                             :is-signed="matchData.is_sign_team_dom === 1 && matchData.is_sign_team_ext === 1"
+                            mode="add"
                             @add-player="addPlayer">
                     </player-list>
                     <div class="border border-2 border-black">
@@ -86,6 +88,7 @@ $user_details = $_SESSION;
                                 :players="renforts.filter(player => !matchPlayers.includes(player))"
                                 team-name="Renfort"
                                 :is-signed="matchData.is_sign_team_dom === 1 && matchData.is_sign_team_ext === 1"
+                                mode="add"
                                 @add-player="addPlayer">
                         </player-list>
                     </div>
@@ -96,18 +99,21 @@ $user_details = $_SESSION;
                             :players="matchPlayers.filter(player => player.equipe === matchData.equipe_dom)"
                             :team-name="matchData.equipe_dom"
                             :is-signed="matchData.is_sign_team_dom === 1 && matchData.is_sign_team_ext === 1"
+                            mode="remove"
                             @remove-player="removePlayer">
                     </player-list>
                     <player-list
                             :players="matchPlayers.filter(player => player.equipe === matchData.equipe_ext)"
                             :team-name="matchData.equipe_ext"
                             :is-signed="matchData.is_sign_team_dom === 1 && matchData.is_sign_team_ext === 1"
+                            mode="remove"
                             @remove-player="removePlayer">
                     </player-list>
                     <player-list
                             :players="matchPlayers.filter(player => player.equipe !== matchData.equipe_ext && player.equipe !== matchData.equipe_dom)"
                             team-name="Renfort"
                             :is-signed="matchData.is_sign_team_dom === 1 && matchData.is_sign_team_ext === 1"
+                            mode="remove"
                             @remove-player="removePlayer">
                     </player-list>
                 </div>

--- a/team_sheets.php
+++ b/team_sheets.php
@@ -21,6 +21,7 @@ try {
 }
 @session_start();
 $user_details = $_SESSION;
+require_once __DIR__ . '/helpers/vite.php';
 ?>
 <!DOCTYPE html>
 <HTML data-theme="cupcake" lang="fr">
@@ -28,21 +29,7 @@ $user_details = $_SESSION;
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Gestion des Joueurs</title>
-    <!--TOASTER-->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css">
-    <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
-    <!--VUE-->
-    <script src="https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.js"></script>
-    <!--AXIOS-->
-    <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
-    <!-- TAILWIND-->
-    <script src="https://cdn.tailwindcss.com"></script>
-    <!--DAISYUI-->
-    <link href="https://cdn.jsdelivr.net/npm/daisyui@4.12.2/dist/full.min.css" rel="stylesheet" type="text/css"/>
-    <!--    FONT AWESOME-->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.1/css/all.min.css"
-          integrity="sha512-MV7K8+y+gLIBoVD59lQIYicR65iaqukzvf/nwasF0nqhPay5w/9lJmVM2hMDcnK1OnMGCdVK+iQrJ7lzPJQd1w=="
-          crossorigin="anonymous" referrerpolicy="no-referrer"/>
+    <?= vite_asset('src/css/app.css') ?>
 </HEAD>
 <BODY>
 <div id="app" class="max-w-3xl mx-auto p-6">
@@ -127,6 +114,6 @@ $user_details = $_SESSION;
     </div>
 
 </div>
-<script src="/team_sheets.js" type="module"></script>
+<?= vite_asset('team_sheets.js') ?>
 </BODY>
 </HTML>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,51 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import { resolve } from 'node:path';
+
+/**
+ * Multi-page app : on déclare ici toutes les entrées qui ont besoin d'être
+ * bundlées. Chaque entrée produit un fichier hashé dans dist/ + une entrée
+ * dans dist/.vite/manifest.json que le helper PHP vite_asset() utilise pour
+ * émettre les <script>/<link> dans les <head> des pages PHP.
+ *
+ * Pour PR 1 (outillage) on ne bundle que l'entrée CSS — ça valide la chaîne
+ * Tailwind/PostCSS/DaisyUI et permet aux pages converties à partir de PR 3
+ * d'avoir leurs styles. Les entrées JS seront ajoutées une par une au fur et
+ * à mesure que les pages sont migrées Vue 2 → Vue 3 + bundlées.
+ *
+ * Entrées JS à ajouter dans PR 3 (template — décommenter au fil de l'eau) :
+ *
+ *   'pages/home':    'pages/home.js',
+ *   'pages/my_page': 'pages/my_page.js',
+ *   'live':          'live.js',
+ *   'match':         'match.js',
+ *   'survey':        'survey.js',
+ *   'team_sheets':   'team_sheets.js',
+ *   'admin/matches': 'admin/matches.js',
+ */
+const entries = {
+    'css/app': 'src/css/app.css',
+};
+
+export default defineConfig({
+    root: __dirname,
+    base: '/dist/',
+    plugins: [vue()],
+    build: {
+        outDir: 'dist',
+        emptyOutDir: true,
+        manifest: true,
+        rollupOptions: {
+            input: Object.fromEntries(
+                Object.entries(entries).map(([name, file]) => [name, resolve(__dirname, file)])
+            ),
+        },
+    },
+    server: {
+        host: '0.0.0.0',
+        port: 5173,
+        strictPort: true,
+        cors: true,
+        origin: 'http://localhost:5173',
+    },
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,34 +3,48 @@ import vue from '@vitejs/plugin-vue';
 import { resolve } from 'node:path';
 
 /**
- * Multi-page app : on déclare ici toutes les entrées qui ont besoin d'être
- * bundlées. Chaque entrée produit un fichier hashé dans dist/ + une entrée
- * dans dist/.vite/manifest.json que le helper PHP vite_asset() utilise pour
- * émettre les <script>/<link> dans les <head> des pages PHP.
+ * Multi-page app : on déclare ici toutes les entrées qui doivent être bundlées.
  *
- * Pour PR 1 (outillage) on ne bundle que l'entrée CSS — ça valide la chaîne
- * Tailwind/PostCSS/DaisyUI et permet aux pages converties à partir de PR 3
- * d'avoir leurs styles. Les entrées JS seront ajoutées une par une au fur et
- * à mesure que les pages sont migrées Vue 2 → Vue 3 + bundlées.
+ * Deux types d'entrées :
  *
- * Entrées JS à ajouter dans PR 3 (template — décommenter au fil de l'eau) :
+ *  1. Fichiers .js purs (pour les pages .php existantes) — Vite produit un
+ *     fichier hashé dans dist/assets/ et une entrée dans manifest.json. La
+ *     page .php utilise le helper PHP `vite_asset()` pour émettre la bonne
+ *     balise <script> avec le hash courant.
  *
- *   'pages/home':    'pages/home.js',
- *   'pages/my_page': 'pages/my_page.js',
- *   'live':          'live.js',
- *   'match':         'match.js',
- *   'survey':        'survey.js',
- *   'team_sheets':   'team_sheets.js',
- *   'admin/matches': 'admin/matches.js',
+ *  2. Fichiers .html (pour les pages HTML pures) — Vite parse le HTML, bundle
+ *     les <script type="module"> et <link rel="stylesheet"> qu'il trouve, et
+ *     produit un dist/.../page.html avec les scripts/links remplacés par les
+ *     bundles hashés. Apache .htaccess rewrite ces URLs vers dist/.
  */
 const entries = {
+    // CSS global (Tailwind + DaisyUI + libs tierces)
     'css/app': 'src/css/app.css',
+
+    // Pages .php (entrées JS, chargées via vite_asset() côté PHP)
+    'live':        'live.js',
+    'match':       'match.js',
+    'survey':      'survey.js',
+    'team_sheets': 'team_sheets.js',
+
+    // Pages .html (entrées HTML natives, Vite remplace les scripts inline)
+    'pages/home':    'pages/home.html',
+    'pages/my_page': 'pages/my_page.html',
+    'admin/matches': 'admin/matches.html',
 };
 
 export default defineConfig({
     root: __dirname,
     base: '/dist/',
     plugins: [vue()],
+    resolve: {
+        alias: {
+            // Notre code utilise des templates en string (`template: '...'`) dans
+            // les composants Options API. Il faut donc le build "esm-bundler"
+            // qui inclut le compilateur de templates runtime, pas le runtime-only.
+            'vue': 'vue/dist/vue.esm-bundler.js',
+        },
+    },
     build: {
         outDir: 'dist',
         emptyOutDir: true,


### PR DESCRIPTION
Closes #223.

Migration complète du frontend vers une chaîne de build **Node.js / Vite / Tailwind / Vue 3** avec suppression de toutes les dépendances CDN externes. La PR englobe les 3 phases du chantier sur une seule branche (`feature/issue-223`), à merger d'un seul bloc.

## Phase 1 — Outillage Vite

Commit [`560868dd`](../commit/560868dd) — `feat(build): mise en place Vite + Tailwind pour bundling frontend`

- **`package.json`** — Vite 5, Vue 3, vue-router 4, Tailwind 3, DaisyUI 4, axios, notyf, toastify-js, fontawesome-free, brackets-viewer.
- **`vite.config.js`** — Multi-entry avec `manifest: true`.
- **`tailwind.config.js`** + **`postcss.config.js`** — Scan `pages/`, `admin/`, `src/`, `.php`. DaisyUI en plugin (thèmes `light` + `cupcake`).
- **`src/css/app.css`** — Imports tiers (FontAwesome, Notyf, Toastify) + directives Tailwind.
- **`helpers/vite.php`** — Fonction `vite_asset()` qui lit `dist/.vite/manifest.json` et émet les `<script>`/`<link>` hashés. Mode dev (`APP_ENV=dev`) → dev server Vite (`http://localhost:5173`) pour HMR.
- **`Dockerfile`** — Étape multi-stage `frontend_builder` (`node:20-alpine`) qui fait `npm install` + `npm run build` puis copie `/app/dist` dans l'image PHP finale. `a2enmod rewrite` ajouté pour activer `mod_rewrite`.
- **`.gitignore`** + **`.dockerignore`** — Exclusion `node_modules/` et `dist/`.

## Phase 2 — Migration Vue 2 → Vue 3

Commits [`b15c13c6`](../commit/b15c13c6) + [`9dd92d27`](../commit/9dd92d27)

- **7 entrées migrées** en `Vue.createApp().mount()` (initialement via CDN Vue 3 pour valider la migration indépendamment du bundle).
  - `data: { ... }` enveloppé en `data() { return { ... }; }` (requis Vue 3).
  - `el` déplacé en argument de `.mount()`.
  - Layouts : `app.use(Layout.router)` pour installer vue-router 4 comme plugin.
- **2 routers** migrés vers `VueRouter.createRouter({ history: VueRouter.createWebHashHistory(), routes })`. Route catch-all `*` → `/:pathMatch(.*)*` (nouvelle syntaxe v4).
- **Réactivité proxy-based Vue 3** : 14 `this.$set(obj, key, val)` → `obj[key] = val` dans `live.js`, 8 `$set`/`$delete` → assignation/delete directs dans `CupDrawAdmin.js`.
- **`team_sheets.js` refactor** :
  - `Vue.component('player-list', ...)` (API globale supprimée en Vue 3) → composant local dans `components: {}` du root.
  - `$listeners['add-player']` (supprimé en Vue 3) → prop `mode` explicite (`'add'` / `'remove'`). Les 6 invocations `<player-list>` dans `team_sheets.php` reçoivent `mode="..."`.
- **`defineAsyncComponent` fix** — `components: { x: () => import(...) }` ne fonctionne plus en Vue 3 → enrobé dans `Vue.defineAsyncComponent(() => import(...))` dans 10 fichiers (21 occurrences). Sans ça les composants async rendaient `[object Promise]`.

## Phase 3 — Bundling Vite + suppression des CDN

Commit [`75040be1`](../commit/75040be1)

**Stratégie par type de page** :

- **4 pages `.php`** (`live`, `match`, `survey`, `team_sheets`) — PHP conservé pour les checks d'auth/session. Utilisent le helper `vite_asset()` pour émettre les balises avec les fichiers hashés du manifest.
- **3 pages `.html`** pures (`pages/home.html`, `pages/my_page.html`, `admin/matches.html`) — Deviennent des **entrées HTML natives Vite**. Vite parse le HTML, bundle les `<script type="module">` et `<link>` relatifs, et produit `dist/<chemin>.html` avec les balises remplacées. Aucun PHP impliqué.
- **`.htaccess`** — `RewriteRule` qui mappe les URLs publiques (`/pages/home.html` etc.) vers `/dist/...`. URLs inchangées pour les utilisateurs et les bookmarks.

**Imports ES** :
- `Vue.createApp` → `import { createApp } from 'vue'`
- `Vue.defineAsyncComponent` → `import { defineAsyncComponent } from 'vue'`
- `VueRouter.createRouter` / `createWebHashHistory` → `import { ... } from 'vue-router'`

**Libs globales** (axios, Toastify, Notyf) — Importées en tête de chaque entrée et exposées sur `window` pour préserver l'usage `axios.get(...)` dans les ~39 sous-composants sans avoir à toucher chaque fichier individuellement. (Une approche par `globals.js` séparé a été tentée mais Vite tree-shake les fichiers à side-effects uniquement → exclure de la liste des entrées.)

**`vite.config.js`** :
- 8 entrées dans `rollupOptions.input` (CSS + 4 JS + 3 HTML).
- Alias `vue` → `vue/dist/vue.esm-bundler.js` pour inclure le **compilateur de templates runtime** (nos composants Options API utilisent `template: '...'` en string).

## Vérification end-to-end

Smoke test browser via Claude in Chrome MCP :

- **`/pages/home.html#/home`** — Logo, navbar (Accueil / Championnats / Coupes / Informations / connexion / inscrire une équipe), liste "dernières nouvelles" chargée via axios, carousel photos. ✅
- **`/live.php`** — Header, "Matchs en direct", alerte "Aucun match en direct actuellement". ✅
- **`/admin/matches.html`** — 553 matchs chargés via axios, cards avec scores/badges/dates. ✅
- **`read_network_requests`** sur 136 requêtes → **0 vers `cdn.jsdelivr.net`, `unpkg.com`, `cdnjs.cloudflare.com`, `cdn.tailwindcss.com`**. Les seules requêtes externes sont les photos du carousel (Flickr) et c'est intentionnel.

## Hors périmètre de cette PR (tickets à part)

- **Interface admin ExtJS** (`admin.php`, `register.php`, `reset_password.php`, `rank_for_cup.php`) — Reste sur ses CDN ExtJS, à traiter dans un ticket dédié.
- **Mode dev HMR** via Caddy reverse-proxy vers `localhost:5173` — Le helper `vite_asset()` est déjà prêt côté PHP (détecte `APP_ENV=dev`) ; il manque la config Caddy. Ticket séparé.

## Notes

- Le `dist/` n'est pas versionné. Il faut donc adapter le CI/CD (`.github/workflows/main.yml`) pour ajouter une étape Node + `npm ci` + `npm run build` + transfert du `dist/` vers OVH avant le merge en prod.
- Encodage : tous les nouveaux fichiers en LF (vérifié, warnings Git CRLF dûs à `core.autocrlf` Windows seulement, le contenu indexé reste LF).
