### PR TITLE
feat(#230): refonte mobile-first de la page d'accueil (matchs du jour + nouvelles repliables)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,7 @@ test.afterAll(async ({ request }) => {
 - `test_verify.php` — vérifie les scores en base après `save_to_match`
 - `finals_setup.php` / `finals_teardown.php` — matchs 1/8 finale KF/CF (issue #215)
 - `messages_setup.php` / `messages_teardown.php` — emails non lus pour responsable d'équipe (issue #221)
+- `today_matches_setup.php` / `today_matches_teardown.php` — match programmé aujourd'hui + une nouvelle, pour l'encart "Matchs du jour" et les nouvelles repliables de la home (issue #230). Le setup recopie les FK d'un match déjà visible dans `matchs_view` (échantillonnage **depuis la vue**, pas la table `matches`, pour éviter les matchs orphelins).
 
 ### Installer les dépendances PHP
 ```bash

--- a/classes/MatchMgr.php
+++ b/classes/MatchMgr.php
@@ -189,6 +189,42 @@ class MatchMgr extends Generic
     }
 
     /**
+     * Matchs programmés aujourd'hui (date_reception = date du jour), triés par
+     * heure. Utilisé par l'encart "Matchs du jour" de la page d'accueil (#230).
+     *
+     * Endpoint PUBLIC : on ne renvoie qu'un sous-ensemble whitelisté des champs
+     * (matchs_view contient des emails d'équipe qu'il ne faut pas exposer).
+     * date_reception est stockée au format dd/mm/yyyy → STR_TO_DATE pour comparer
+     * à CURDATE().
+     *
+     * @return array
+     * @throws Exception
+     */
+    public function getMatchesOfTheDay(): array
+    {
+        $matches = $this->get_matches(
+            "STR_TO_DATE(m.date_reception, '%d/%m/%Y') = CURDATE() AND m.match_status != 'ARCHIVED'",
+            "heure_reception"
+        );
+        return array_map(static function ($m) {
+            return array(
+                'id_match' => $m['id_match'],
+                'code_match' => $m['code_match'],
+                'code_competition' => $m['code_competition'],
+                'libelle_competition' => $m['libelle_competition'] ?? null,
+                'division' => $m['division'],
+                'equipe_dom' => $m['equipe_dom'],
+                'equipe_ext' => $m['equipe_ext'],
+                'date_reception' => $m['date_reception'],
+                'heure_reception' => $m['heure_reception'],
+                'gymnasium' => $m['gymnasium'] ?? null,
+                'score_equipe_dom' => $m['score_equipe_dom'] ?? null,
+                'score_equipe_ext' => $m['score_equipe_ext'] ?? null,
+            );
+        }, $matches);
+    }
+
+    /**
      * @param $id_match
      * @return mixed
      * @throws Exception

--- a/e2e/helpers/today_matches_setup.php
+++ b/e2e/helpers/today_matches_setup.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * E2E test helper (#230) — crée un VRAI match programmé aujourd'hui afin de
+ * valider l'encart "Matchs du jour" de la page d'accueil.
+ *
+ * matchs_view fait plusieurs INNER JOIN (competitions, equipes, gymnase et
+ * JOURNEES via id_journee). Pour que la ligne remonte dans la vue, on recopie
+ * toutes les clés étrangères d'un match réel déjà visible (y compris
+ * id_journee, qui était la pièce manquante) et on ne change que la date.
+ *
+ * SECURITY: ne doit jamais être déployé en production.
+ */
+$isLocalhost = in_array($_SERVER['REMOTE_ADDR'] ?? '', ['127.0.0.1', '::1'], true);
+$isTestEnv   = getenv('APP_ENV') === 'test';
+if (!$isLocalhost && !$isTestEnv) {
+    http_response_code(403);
+    exit('Forbidden');
+}
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../classes/SqlManager.php';
+
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/../../');
+$dotenv->load();
+
+header('Content-Type: application/json');
+
+try {
+    $sql = new SqlManager();
+
+    // Nettoyage préventif (préfixe court : code_match est en VARCHAR(20))
+    $sql->execute("DELETE FROM live_scores WHERE id_match LIKE 'E2D%'");
+    $sql->execute("DELETE FROM matches WHERE code_match LIKE 'E2D%'");
+
+    // Réutiliser les FK d'un match qui apparaît DÉJÀ dans matchs_view : en
+    // échantillonnant depuis la vue (et non la table matches brute), on garantit
+    // que toutes ses jointures INNER (competitions, equipes, ...) sont déjà
+    // satisfaites — la nouvelle ligne héritera donc de FK valides et remontera
+    // dans la vue. (Échantillonner depuis `matches` risquait de tomber sur un
+    // match orphelin, ex. compétition 'ut' supprimée.)
+    // id_journee / id_gymnasium sont des LEFT JOIN dans la vue (non requis pour
+    // la visibilité), donc on n'impose pas qu'ils soient non-null : on prend
+    // n'importe quelle ligne de la vue.
+    $sample = $sql->execute(
+        "SELECT code_competition, division, id_equipe_dom, id_equipe_ext, id_gymnasium, id_journee
+         FROM matchs_view
+         LIMIT 1"
+    );
+    if (empty($sample)) {
+        throw new Exception("Aucun match modèle dans matchs_view en base de test.");
+    }
+    $s = $sample[0];
+
+    $code_match = 'E2D' . date('ymdHis'); // 3 + 12 = 15 car. (<= VARCHAR(20))
+
+    // id_gymnasium peut être null dans l'échantillon ; on l'omet alors du SET.
+    $hasGym = !empty($s['id_gymnasium']);
+    $gymClause = $hasGym ? "id_gymnasium = ?," : "";
+
+    $bindings = [
+        ['type' => 's', 'value' => $code_match],
+        ['type' => 's', 'value' => $s['code_competition']],
+        ['type' => 's', 'value' => $s['division']],
+        ['type' => 'i', 'value' => (int)$s['id_equipe_dom']],
+        ['type' => 'i', 'value' => (int)$s['id_equipe_ext']],
+    ];
+    if ($hasGym) {
+        $bindings[] = ['type' => 'i', 'value' => (int)$s['id_gymnasium']];
+    }
+
+    $sql->execute(
+        "INSERT INTO matches SET
+            code_match       = ?,
+            code_competition = ?,
+            division         = ?,
+            id_equipe_dom    = ?,
+            id_equipe_ext    = ?,
+            $gymClause
+            date_reception   = CURRENT_DATE,
+            date_original    = CURRENT_DATE,
+            match_status     = 'CONFIRMED'",
+        $bindings
+    );
+
+    // Nouvelle de test (pour valider l'affichage repliable des dernières
+    // nouvelles). is_disabled = 0 pour qu'elle remonte dans getLastNews.
+    $sql->execute("DELETE FROM news WHERE title = 'E2E News test'");
+    $sql->execute(
+        "INSERT INTO news (title, text, file_path, news_date, is_disabled) VALUES (?, ?, ?, NOW(), 0)",
+        [
+            ['type' => 's', 'value' => 'E2E News test'],
+            ['type' => 's', 'value' => '<p>Contenu detaille E2E test</p>'],
+            ['type' => 's', 'value' => ''],
+        ]
+    );
+
+    echo json_encode(['success' => true, 'code_match' => $code_match]);
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}

--- a/e2e/helpers/today_matches_teardown.php
+++ b/e2e/helpers/today_matches_teardown.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * E2E test helper (#230) — supprime le match "du jour" créé par
+ * today_matches_setup.php (préfixe E2D).
+ *
+ * SECURITY: ne doit jamais être déployé en production.
+ */
+$isLocalhost = in_array($_SERVER['REMOTE_ADDR'] ?? '', ['127.0.0.1', '::1'], true);
+$isTestEnv   = getenv('APP_ENV') === 'test';
+if (!$isLocalhost && !$isTestEnv) {
+    http_response_code(403);
+    exit('Forbidden');
+}
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../classes/SqlManager.php';
+
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/../../');
+$dotenv->load();
+
+header('Content-Type: application/json');
+
+try {
+    $sql = new SqlManager();
+    $sql->execute("DELETE FROM live_scores WHERE id_match LIKE 'E2D%'");
+    $sql->execute("DELETE FROM matches WHERE code_match LIKE 'E2D%'");
+    $sql->execute("DELETE FROM news WHERE title = 'E2E News test'");
+    echo json_encode(['success' => true]);
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}

--- a/e2e/tests/home_today_matches.spec.js
+++ b/e2e/tests/home_today_matches.spec.js
@@ -1,0 +1,59 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+/**
+ * E2E — Refonte mobile-first de la page d'accueil (issue #230)
+ *
+ *  1. Setup : créer un VRAI match programmé aujourd'hui (helper PHP qui recopie
+ *     les FK d'un match existant pour qu'il remonte dans matchs_view).
+ *  2. Ouvrir la home et vérifier que l'encart "Matchs du jour" apparaît avec un
+ *     lien vers le live score du match créé.
+ *  3. Vérifier que les dernières nouvelles sont repliées et se déplient au tap.
+ *  4. Teardown : supprimer le match de test.
+ */
+
+test.describe('Issue #230 — Page d\'accueil mobile-first', () => {
+    let codeMatch = null;
+
+    test.beforeAll(async ({ request }) => {
+        const res = await request.get('/e2e/helpers/today_matches_setup.php');
+        const body = await res.json();
+        if (body.error) throw new Error(`Setup failed: ${body.error}`);
+        expect(res.status()).toBe(200);
+        expect(body.success).toBe(true);
+        codeMatch = body.code_match;
+    });
+
+    test.afterAll(async ({ request }) => {
+        await request.get('/e2e/helpers/today_matches_teardown.php');
+        codeMatch = null;
+    });
+
+    test('l\'encart "Matchs du jour" affiche le match du jour avec un lien live', async ({ page }) => {
+        await page.goto('/pages/home.html#/home');
+
+        await expect(page.getByText('Matchs du jour')).toBeVisible({ timeout: 10000 });
+
+        const liveLink = page.locator(`a[href="/live.html?id_match=${codeMatch}"]`);
+        await expect(liveLink).toBeVisible();
+        await expect(liveLink).toContainText('Live score');
+    });
+
+    test('les dernières nouvelles sont repliées et se déplient au tap', async ({ page }) => {
+        await page.goto('/pages/home.html#/home');
+
+        await expect(page.getByText('dernières nouvelles')).toBeVisible({ timeout: 10000 });
+
+        // Le setup a seedé au moins une nouvelle : on attend que le bouton (titre)
+        // soit rendu par le fetch async.
+        const firstNews = page.locator('button[aria-expanded]').first();
+        await expect(firstNews).toBeVisible({ timeout: 10000 });
+
+        // Replié par défaut
+        await expect(firstNews).toHaveAttribute('aria-expanded', 'false');
+        // Déplié au tap
+        await firstNews.click();
+        await expect(firstNews).toHaveAttribute('aria-expanded', 'true');
+        await expect(page.locator('.prose').first()).toBeVisible();
+    });
+});

--- a/pages/components/panel/Home.js
+++ b/pages/components/panel/Home.js
@@ -2,12 +2,14 @@ import { defineAsyncComponent } from 'vue';
 
 export default {
     components: {
+        'today-matches': defineAsyncComponent(() => import('./TodayMatches.js')),
         'news': defineAsyncComponent(() => import('../table/News.js')),
         'photos': defineAsyncComponent(() => import('../carousel/Photos.js')),
         'annual-calendar': defineAsyncComponent(() => import('../calendar/AnnualCalendar.js')),
     },
     template: `
-      <div class="flex flex-col items-center gap-8">
+      <div class="flex flex-col items-center gap-8 px-2">
+        <today-matches/>
         <news/>
         <annual-calendar :events="importantEvents"/>
         <photos/>

--- a/pages/components/panel/TodayMatches.js
+++ b/pages/components/panel/TodayMatches.js
@@ -1,0 +1,67 @@
+/**
+ * Encart "Matchs du jour" de la page d'accueil (#230).
+ *
+ * Affiche les matchs programmés aujourd'hui (endpoint public
+ * matchmgr/getMatchesOfTheDay), avec un lien vers le live score de chaque match.
+ * Ne s'affiche QUE s'il y a au moins un match aujourd'hui (sinon rien).
+ * Pensé mobile-first : cartes empilées, pleine largeur, zones tactiles larges.
+ */
+export default {
+    template: `
+      <section v-if="matches.length > 0" class="w-full max-w-2xl">
+        <h2 class="text-2xl font-bold text-primary text-center mb-3">
+          <i class="fas fa-volleyball mr-2"></i>Matchs du jour
+        </h2>
+        <div class="flex flex-col gap-3">
+          <a v-for="match in matches" :key="match.id_match"
+             :href="'/live.html?id_match=' + match.code_match"
+             class="card bg-base-100 shadow-md border border-base-300 active:scale-[0.99] transition-transform">
+            <div class="card-body p-4">
+              <div class="flex items-center justify-between gap-2">
+                <span class="badge badge-info badge-sm">{{ match.libelle_competition }}</span>
+                <span class="text-sm font-mono opacity-70">{{ formatHeure(match.heure_reception) }}</span>
+              </div>
+              <div class="flex items-center justify-center gap-2 text-center font-bold text-base my-1">
+                <span class="flex-1 text-right">{{ match.equipe_dom }}</span>
+                <span class="opacity-50">vs</span>
+                <span class="flex-1 text-left">{{ match.equipe_ext }}</span>
+              </div>
+              <div class="flex items-center justify-between gap-2 text-xs opacity-70">
+                <span><i class="fas fa-location-dot mr-1"></i>{{ match.gymnasium }}</span>
+                <span class="text-primary font-semibold">
+                  <i class="fas fa-circle-play mr-1"></i>Live score
+                </span>
+              </div>
+            </div>
+          </a>
+        </div>
+      </section>
+    `,
+    data() {
+        return {
+            matches: [],
+        };
+    },
+    methods: {
+        formatHeure(heure) {
+            // "20:30:00" -> "20:30"
+            if (!heure) {
+                return '';
+            }
+            return heure.toString().slice(0, 5);
+        },
+        fetch() {
+            axios
+                .get('/rest/action.php/matchmgr/getMatchesOfTheDay')
+                .then((response) => {
+                    this.matches = Array.isArray(response.data) ? response.data : [];
+                })
+                .catch((error) => {
+                    console.error('Erreur lors du chargement des matchs du jour:', error);
+                });
+        },
+    },
+    created() {
+        this.fetch();
+    },
+};

--- a/pages/components/table/News.js
+++ b/pages/components/table/News.js
@@ -1,41 +1,66 @@
+/**
+ * Dernières nouvelles — liste mobile-first repliable (#230).
+ *
+ * Affiche uniquement le titre (+ date) de chaque nouvelle ; un tap sur le titre
+ * déplie le détail (texte + lien éventuel). Remplace l'ancien tableau large peu
+ * lisible sur smartphone. Endpoint inchangé : news/getLastNews.
+ */
 export default {
     template: `
-      <div class="bg-base-100">
-        <div class="text-center mt-4">
-          <div class="text-2xl font-bold text-primary">dernières nouvelles</div>
+      <section class="w-full max-w-2xl">
+        <h2 class="text-2xl font-bold text-primary text-center mb-3">dernières nouvelles</h2>
+        <div class="flex flex-col gap-2">
+          <div v-for="item in items" :key="item.id"
+               class="card bg-base-100 border border-base-300 shadow-sm">
+            <button type="button"
+                    class="flex items-center justify-between gap-2 w-full text-left p-4 min-h-[44px]"
+                    :aria-expanded="isOpen(item.id)"
+                    @click="toggle(item.id)">
+              <span class="flex flex-col">
+                <span class="font-semibold">{{ item.title }}</span>
+                <span class="text-xs opacity-60">{{ item.news_date }}</span>
+              </span>
+              <i class="fas fa-chevron-down transition-transform shrink-0"
+                 :class="{ 'rotate-180': isOpen(item.id) }"></i>
+            </button>
+            <div v-if="isOpen(item.id)" class="px-4 pb-4 border-t border-base-200 pt-3">
+              <div class="prose max-w-none text-sm" v-html="item.text"></div>
+              <a v-if="item.file_path && item.file_path.length > 0"
+                 class="link link-primary inline-block mt-2 text-sm"
+                 :href="item.file_path" target="_blank" rel="noopener">
+                <i class="fas fa-up-right-from-square mr-1"></i>lire le document
+              </a>
+            </div>
+          </div>
+          <p v-if="items.length === 0" class="text-center opacity-60 text-sm py-4">
+            Aucune nouvelle pour le moment.
+          </p>
         </div>
-        <table class="table table-pin-rows">
-          <thead>
-          <tr>
-            <th>titre</th>
-            <th>texte</th>
-            <th>lien</th>
-            <th>date</th>
-          </tr>
-          </thead>
-          <tbody>
-          <tr v-for="item in items" :key="item.id">
-            <td>{{ item.title }}</td>
-            <td v-html="item.text"></td>
-            <td><a class="link" v-if="item.file_path.length > 0" :href="item.file_path" target="_blank">lire...</a></td>
-            <td>{{ item.news_date }}</td>
-          </tr>
-          </tbody>
-        </table>
-      </div>
+      </section>
     `,
     data() {
         return {
             items: [],
+            openIds: [],
             fetchUrl: "/rest/action.php/news/getLastNews"
         };
     },
     methods: {
+        isOpen(id) {
+            return this.openIds.includes(id);
+        },
+        toggle(id) {
+            if (this.openIds.includes(id)) {
+                this.openIds = this.openIds.filter((openId) => openId !== id);
+            } else {
+                this.openIds.push(id);
+            }
+        },
         fetch() {
             axios
                 .get(this.fetchUrl)
                 .then((response) => {
-                    this.items = response.data;
+                    this.items = Array.isArray(response.data) ? response.data : [];
                 })
                 .catch((error) => {
                     console.error("Erreur lors du chargement:", error);


### PR DESCRIPTION
## Objectif

Refonte mobile-first de la page d'accueil (`/pages/home.html#/home`), la plus consultée et le plus souvent sur smartphone (#230).

## Changements

### 1. Encart « Matchs du jour » (option A)
- Nouveau composant `pages/components/panel/TodayMatches.js`, affiché **en haut** de la home, **uniquement s'il y a des matchs programmés aujourd'hui**.
- Chaque match : compétition, heure, équipes, gymnase + **lien vers le live score** (`/live.html?id_match={code_match}`).
- Nouvel endpoint **`MatchMgr::getMatchesOfTheDay()`** (`date_reception = CURDATE()`). Endpoint **public** → champs whitelistés (pas d'email/PII de `matchs_view`).

### 2. Dernières nouvelles repliables
- `pages/components/table/News.js` refondu : liste verticale mobile-first, **titre + date seuls**, **détail dépliable au tap** (remplace le tableau large illisible sur mobile). Endpoint inchangé (`news/getLastNews`).

### 3. Hiérarchie mobile
- `pages/components/panel/Home.js` : sections empilées et ordonnées (matchs du jour → nouvelles → calendrier → photos).

## Tests

- **E2E** `e2e/tests/home_today_matches.spec.js` (+ helpers `today_matches_setup/teardown.php`) :
  - encart « Matchs du jour » présent avec lien live vers le match seedé ;
  - dernières nouvelles repliées par défaut, dépliées au tap.
- Le helper de seed recopie les FK d'un match **déjà visible dans `matchs_view`** (échantillonnage depuis la vue, pas la table `matches`, pour éviter les matchs orphelins dont la compétition a été supprimée).
- **Suite E2E complète : 22/22 verts.**
- Vérifié manuellement en prod (biggyben) : endpoint OK, encart masqué quand vide, encart + liens live OK avec données, nouvelles dépliables, rendu mobile 390px propre.

## Hors périmètre

- Badge « LIVE » croisant les lives actifs (amélioration future notée dans #230).
- Refonte des autres pages.

Closes #230
