### PR TITLE
ci: bump webfactory/ssh-agent vers v0.10.0 (Node 24)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
         run: npm run build
 
       - name: Setup SSH
-        uses: webfactory/ssh-agent@v0.8.0
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 


### PR DESCRIPTION
## Contexte

GitHub Actions a déprécié Node 20 : l'action `webfactory/ssh-agent@v0.8.0` (utilisée dans `main.yml` pour le déploiement) tourne sur Node 20.
- Node 24 forcé par défaut le **16/06/2026**
- Node 20 retiré des runners le **16/09/2026**

## Changement

Bump `webfactory/ssh-agent` **v0.8.0 → v0.10.0**, qui utilise le runtime `node24` (vérifié dans son `action.yml`). v0.9.x est encore en node20, donc on saute directement à v0.10.0.

Après ce bump, **toutes les actions des workflows sont compatibles Node 24** :
- `actions/checkout@v5` (node24)
- `actions/setup-node@v5` (node24)
- `webfactory/ssh-agent@v0.10.0` (node24)

## Validation

L'étape ssh-agent ne s'exécute que dans `main.yml`, déclenché par un tag → ce sera validé au prochain déploiement prod (bump de version vers une release node24 connue, faible risque).