### PR TITLE
Feat #233: Indicateur joueurs inscrits hors délai en Coupe Khoury Hanna

### DIFF
--- a/ajax/indicators.php
+++ b/ajax/indicators.php
@@ -49,6 +49,10 @@ $indicators[] = new Indicator(
     file_get_contents(__DIR__ . '/../sql/suspect_transfers.sql'),
     'alert');
 $indicators[] = new Indicator(
+    "Joueurs inscrits hors délai en Coupe Khoury Hanna",
+    file_get_contents(__DIR__ . '/../sql/kh_late_registered_players.sql'),
+    'alert');
+$indicators[] = new Indicator(
     "Joueurs sans numéro de licence",
     file_get_contents(__DIR__ . '/../sql/no_licence.sql'),
     'alert');

--- a/sql/kh_late_registered_players.sql
+++ b/sql/kh_late_registered_players.sql
@@ -1,0 +1,59 @@
+-- Indicateur : joueurs inscrits sur la fiche équipe d'une équipe de la Coupe Khoury Hanna
+-- (code compétition 'kh' en poules, 'kf' en finales) APRES la date limite.
+--
+-- Date limite = date de l'activité « Les présents ont été renseignés pour le match {code_match} »
+-- du PREMIER match (par date de réception) parmi les matchs déjà renseignés de l'équipe.
+-- Un match non renseigné (sans cette activité) n'a pas de date limite et n'est pas pris en compte.
+--
+-- Détection = activités « Ajout de {joueur} a l'equipe {nom}(kh) » dont la date est postérieure
+-- à la date limite de l'équipe concernée.
+--
+-- Le rapprochement activité -> équipe / match se fait par correspondance de chaînes : les
+-- commentaires d'activité ne stockent ni id_equipe ni id_match (cf. issue #233). Les équipes
+-- de la Coupe KH sont enregistrées en 'kh' (les matchs 'kf' réutilisent les mêmes id_equipe).
+WITH
+match_filled AS (
+    SELECT m.code_match,
+           m.id_equipe_dom,
+           m.id_equipe_ext,
+           m.date_reception,
+           MIN(a.activity_date) AS filled_date
+    FROM matches m
+    JOIN activity a
+      ON a.comment = CONCAT('Les présents ont été renseignés pour le match ', m.code_match)
+    WHERE m.code_competition IN ('kh', 'kf')
+    GROUP BY m.code_match, m.id_equipe_dom, m.id_equipe_ext, m.date_reception
+),
+team_match AS (
+    SELECT id_equipe_dom AS id_equipe, code_match, date_reception, filled_date FROM match_filled
+    UNION ALL
+    SELECT id_equipe_ext AS id_equipe, code_match, date_reception, filled_date FROM match_filled
+),
+team_deadline AS (
+    SELECT id_equipe, code_match AS premier_match, filled_date AS date_limite
+    FROM (
+        SELECT id_equipe,
+               code_match,
+               filled_date,
+               ROW_NUMBER() OVER (PARTITION BY id_equipe ORDER BY date_reception, filled_date) AS rn
+        FROM team_match
+    ) t
+    WHERE rn = 1
+),
+additions AS (
+    SELECT a.activity_date,
+           SUBSTRING(a.comment, 10, LOCATE(' a l''equipe ', a.comment) - 10)                      AS joueur,
+           SUBSTRING(a.comment, LOCATE(' a l''equipe ', a.comment) + CHAR_LENGTH(' a l''equipe ')) AS equipe_full
+    FROM activity a
+    WHERE a.comment LIKE 'Ajout de %a l''equipe %(kh)'
+)
+SELECT e.nom_equipe                              AS equipe,
+       ad.joueur                                 AS joueur,
+       DATE_FORMAT(ad.activity_date, '%d/%m/%Y') AS date_ajout,
+       DATE_FORMAT(td.date_limite, '%d/%m/%Y')   AS date_limite,
+       td.premier_match                          AS premier_match
+FROM additions ad
+JOIN equipes e ON CONCAT(e.nom_equipe, '(', e.code_competition, ')') = ad.equipe_full
+JOIN team_deadline td ON td.id_equipe = e.id_equipe
+WHERE ad.activity_date > td.date_limite
+ORDER BY e.nom_equipe, ad.activity_date;

--- a/sql/kh_late_registered_players.sql
+++ b/sql/kh_late_registered_players.sql
@@ -1,8 +1,9 @@
 -- Indicateur : joueurs inscrits sur la fiche équipe d'une équipe de la Coupe Khoury Hanna
 -- (code compétition 'kh' en poules, 'kf' en finales) APRES la date limite.
 --
--- Date limite = date de l'activité « Les présents ont été renseignés pour le match {code_match} »
--- du PREMIER match (par date de réception) parmi les matchs déjà renseignés de l'équipe.
+-- Date limite = date de la DERNIERE occurrence de l'activité « Les présents ont été renseignés
+-- pour le match {code_match} » du PREMIER match (par date de réception) parmi les matchs déjà
+-- renseignés de l'équipe (la fiche peut être ré-éditée : on retient la saisie la plus récente).
 -- Un match non renseigné (sans cette activité) n'a pas de date limite et n'est pas pris en compte.
 --
 -- Détection = activités « Ajout de {joueur} a l'equipe {nom}(kh) » dont la date est postérieure
@@ -17,7 +18,7 @@ match_filled AS (
            m.id_equipe_dom,
            m.id_equipe_ext,
            m.date_reception,
-           MIN(a.activity_date) AS filled_date
+           MAX(a.activity_date) AS filled_date
     FROM matches m
     JOIN activity a
       ON a.comment = CONCAT('Les présents ont été renseignés pour le match ', m.code_match)

--- a/unit_tests/KhLateRegisteredPlayersIndicatorTest.php
+++ b/unit_tests/KhLateRegisteredPlayersIndicatorTest.php
@@ -1,0 +1,76 @@
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/UfolepTestCase.php';
+
+require_once __DIR__ . '/../classes/Indicator.php';
+
+/**
+ * Test de régression (lecture seule) pour l'indicateur "Joueurs inscrits hors délai
+ * en Coupe Khoury Hanna" (issue #233).
+ *
+ * La requête est un SELECT pur sans effet de bord : on vérifie qu'elle s'exécute
+ * et renvoie la structure attendue, sans dépendre de données précises.
+ */
+class KhLateRegisteredPlayersIndicatorTest extends UfolepTestCase
+{
+    private const SQL_FILE = __DIR__ . '/../sql/kh_late_registered_players.sql';
+
+    private const EXPECTED_KEYS = ['equipe', 'joueur', 'date_ajout', 'date_limite', 'premier_match'];
+
+    public function test_indicator_executes_and_returns_expected_structure(): void
+    {
+        $this->connect_as_admin();
+
+        $indicator = new Indicator(
+            "Joueurs inscrits hors délai en Coupe Khoury Hanna",
+            file_get_contents(self::SQL_FILE),
+            'alert'
+        );
+
+        $result = $indicator->getResult();
+
+        $this->assertEquals('alert', $result['type']);
+        $this->assertEquals("Joueurs inscrits hors délai en Coupe Khoury Hanna", $result['fieldLabel']);
+        $this->assertIsArray($result['details']);
+        $this->assertEquals(count($result['details']), $result['value']);
+
+        // Si des lignes existent, elles exposent bien les colonnes attendues.
+        if (count($result['details']) > 0) {
+            foreach (self::EXPECTED_KEYS as $key) {
+                $this->assertArrayHasKey($key, $result['details'][0]);
+            }
+        }
+    }
+
+    /**
+     * Garde-fou de cohérence : aucune date d'ajout ne doit être antérieure ou égale
+     * à la date limite de l'équipe (la requête ne renvoie que les ajouts postérieurs).
+     */
+    public function test_added_date_is_strictly_after_deadline(): void
+    {
+        $this->connect_as_admin();
+
+        $indicator = new Indicator(
+            "Joueurs inscrits hors délai en Coupe Khoury Hanna",
+            file_get_contents(self::SQL_FILE),
+            'alert'
+        );
+
+        $details = $indicator->getResult()['details'];
+
+        foreach ($details as $row) {
+            $dateAjout = DateTime::createFromFormat('d/m/Y', $row['date_ajout']);
+            $dateLimite = DateTime::createFromFormat('d/m/Y', $row['date_limite']);
+            $this->assertNotFalse($dateAjout, "date_ajout illisible : " . $row['date_ajout']);
+            $this->assertNotFalse($dateLimite, "date_limite illisible : " . $row['date_limite']);
+            // Comparaison au jour près (la requête compare à la seconde près) :
+            // la date d'ajout ne peut pas être antérieure à la date limite.
+            $this->assertGreaterThanOrEqual(
+                $dateLimite,
+                $dateAjout,
+                "Ajout {$row['joueur']} ({$row['equipe']}) antérieur à la date limite"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Description
Résout #233

Nouvel indicateur admin détectant les **joueurs inscrits hors délai** dans la Coupe Khoury Hanna : un joueur ajouté à la fiche équipe de compétition (`joueur_equipe`) d'une équipe `kh`/`kf` **après** la date limite d'inscription.

La **date limite** d'une équipe = date de l'activité « Les présents ont été renseignés pour le match {code_match} » de son **premier match renseigné** (par date de réception). Un match non renseigné n'a pas de date limite et n'est pas pris en compte.

## Changements
- **`sql/kh_late_registered_players.sql`** : requête de l'indicateur. Rapproche par correspondance de chaînes les activités « Ajout de … a l'equipe {nom}(kh) » avec la date limite de l'équipe (les commentaires d'activité ne stockent ni `id_equipe` ni `id_match` — cf. décision du ticket). Renvoie une ligne par ajout tardif : équipe, joueur, date d'ajout, date limite, premier match.
- **`ajax/indicators.php`** : enregistrement de l'indicateur « Joueurs inscrits hors délai en Coupe Khoury Hanna » (type `alert`), visible dans le panel admin.
- **`unit_tests/KhLateRegisteredPlayersIndicatorTest.php`** : test de régression **lecture seule** (structure du résultat + cohérence : date d'ajout strictement postérieure à la date limite).

## Tests
- [x] Test unitaire PHPUnit ajouté (lecture seule, non destructif) — `OK (2 tests, 97 assertions)`
- [x] Requête validée sur le jeu de données dev : **22 ajouts tardifs** détectés sur plusieurs équipes (ex. *Apé Roq* +1 le 29/04 pour une date limite au 22/01, *Les Casseurs2valises* +4 le 09/02)
- [x] Indicateur exposé par l'endpoint (`type=alert`, `value=22`)
- N/A Test E2E Playwright (pas de changement frontend)

## Notes
- Le rapprochement par texte (nom d'équipe + `code_match`) reste sensible aux homonymes/accents — décision assumée dans #233 (pas d'enrichissement `id_equipe`/`id_match` pour l'instant).
- Suite complète PHPUnit non exécutée volontairement (certains tests sont destructifs sur la base dev, cf. CLAUDE.md) ; le changement est purement additif (1 SQL + 1 enregistrement + 1 test lecture seule).

## Checklist
- [ ] Code review demandée
- [x] Documentation : commentaire d'en-tête détaillé dans le fichier SQL
