### PR TITLE
Feat #235: Afficher le score final si renseigné (Matchs du jour + live.html)

### DIFF
--- a/classes/MatchMgr.php
+++ b/classes/MatchMgr.php
@@ -220,6 +220,7 @@ class MatchMgr extends Generic
                 'gymnasium' => $m['gymnasium'] ?? null,
                 'score_equipe_dom' => $m['score_equipe_dom'] ?? null,
                 'score_equipe_ext' => $m['score_equipe_ext'] ?? null,
+                'is_match_score_filled' => $m['is_match_score_filled'] ?? null,
             );
         }, $matches);
     }

--- a/e2e/helpers/final_score_setup.php
+++ b/e2e/helpers/final_score_setup.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * E2E test helper (#235) — crée deux VRAIS matchs programmés aujourd'hui :
+ *  - un AVEC score final renseigné (3-0, sets 25-0) → is_match_score_filled = 1
+ *  - un SANS score (0-0)                            → is_match_score_filled = 0
+ *
+ * Sert à valider :
+ *  - l'affichage du score final dans l'encart "Matchs du jour" (home)
+ *  - sur live.html : masquage du bouton scoreur + affichage du score final
+ *
+ * Comme today_matches_setup.php (#230), on recopie les FK d'un match déjà
+ * visible dans matchs_view pour que les nouvelles lignes y remontent.
+ *
+ * SECURITY: ne doit jamais être déployé en production.
+ */
+$isLocalhost = in_array($_SERVER['REMOTE_ADDR'] ?? '', ['127.0.0.1', '::1'], true);
+$isTestEnv   = getenv('APP_ENV') === 'test';
+if (!$isLocalhost && !$isTestEnv) {
+    http_response_code(403);
+    exit('Forbidden');
+}
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../classes/SqlManager.php';
+
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/../../');
+$dotenv->load();
+
+header('Content-Type: application/json');
+
+try {
+    $sql = new SqlManager();
+
+    // Nettoyage préventif (préfixe E2F, code_match en VARCHAR(20))
+    $sql->execute("DELETE FROM live_scores WHERE id_match LIKE 'E2F%'");
+    $sql->execute("DELETE FROM matches WHERE code_match LIKE 'E2F%'");
+
+    // Échantillon depuis la vue : garantit des FK valides (cf. #230).
+    $sample = $sql->execute(
+        "SELECT code_competition, division, id_equipe_dom, id_equipe_ext, id_gymnasium, id_journee
+         FROM matchs_view
+         LIMIT 1"
+    );
+    if (empty($sample)) {
+        throw new Exception("Aucun match modèle dans matchs_view en base de test.");
+    }
+    $s = $sample[0];
+
+    $hasGym = !empty($s['id_gymnasium']);
+    $gymClause = $hasGym ? "id_gymnasium = ?," : "";
+
+    $insertMatch = static function (string $code_match, bool $withScore) use ($sql, $s, $hasGym, $gymClause) {
+        $bindings = [
+            ['type' => 's', 'value' => $code_match],
+            ['type' => 's', 'value' => $s['code_competition']],
+            ['type' => 's', 'value' => $s['division']],
+            ['type' => 'i', 'value' => (int)$s['id_equipe_dom']],
+            ['type' => 'i', 'value' => (int)$s['id_equipe_ext']],
+        ];
+        if ($hasGym) {
+            $bindings[] = ['type' => 'i', 'value' => (int)$s['id_gymnasium']];
+        }
+        // Score final 3-0 : 3 sets gagnés 25-0 par l'équipe domicile.
+        // is_match_score_filled (matchs_view) passe à 1 dès qu'une équipe gagne 3 sets.
+        $scoreClause = $withScore
+            ? "set_1_dom = 25, set_1_ext = 0,
+               set_2_dom = 25, set_2_ext = 0,
+               set_3_dom = 25, set_3_ext = 0,"
+            : "";
+        $sql->execute(
+            "INSERT INTO matches SET
+                code_match       = ?,
+                code_competition = ?,
+                division         = ?,
+                id_equipe_dom    = ?,
+                id_equipe_ext    = ?,
+                $gymClause
+                $scoreClause
+                date_reception   = CURRENT_DATE,
+                date_original    = CURRENT_DATE,
+                match_status     = 'CONFIRMED'",
+            $bindings
+        );
+    };
+
+    $codeScored   = 'E2FS' . date('ymdHis'); // 4 + 12 = 16 car. (<= VARCHAR(20))
+    $codeUnscored = 'E2FN' . date('ymdHis');
+
+    $insertMatch($codeScored, true);
+    $insertMatch($codeUnscored, false);
+
+    echo json_encode([
+        'success'        => true,
+        'code_scored'    => $codeScored,
+        'code_unscored'  => $codeUnscored,
+    ]);
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}

--- a/e2e/helpers/final_score_teardown.php
+++ b/e2e/helpers/final_score_teardown.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * E2E test helper (#235) — supprime les matchs du jour créés par
+ * final_score_setup.php (préfixe E2F).
+ *
+ * SECURITY: ne doit jamais être déployé en production.
+ */
+$isLocalhost = in_array($_SERVER['REMOTE_ADDR'] ?? '', ['127.0.0.1', '::1'], true);
+$isTestEnv   = getenv('APP_ENV') === 'test';
+if (!$isLocalhost && !$isTestEnv) {
+    http_response_code(403);
+    exit('Forbidden');
+}
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../classes/SqlManager.php';
+
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/../../');
+$dotenv->load();
+
+header('Content-Type: application/json');
+
+try {
+    $sql = new SqlManager();
+    $sql->execute("DELETE FROM live_scores WHERE id_match LIKE 'E2F%'");
+    $sql->execute("DELETE FROM matches WHERE code_match LIKE 'E2F%'");
+    echo json_encode(['success' => true]);
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}

--- a/e2e/tests/issue_235.spec.js
+++ b/e2e/tests/issue_235.spec.js
@@ -1,0 +1,82 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+/**
+ * E2E — Afficher le score final si renseigné (issue #235)
+ *
+ * Setup : deux matchs du jour, l'un AVEC score final (3-0), l'autre SANS.
+ *
+ *  Partie A (home, encart "Matchs du jour") :
+ *    - match avec score   → affiche "3 - 0"
+ *    - match sans score   → affiche "vs", pas de score
+ *
+ *  Partie B (live.html) :
+ *    - match avec score   → bouton "Passer en mode scoreur" masqué + "Résultat final"
+ *    - match sans score   → bouton visible, pas de "Résultat final"
+ */
+
+test.describe('Issue #235 — score final (Matchs du jour + live.html)', () => {
+    let codeScored = null;
+    let codeUnscored = null;
+
+    test.beforeAll(async ({ request }) => {
+        const res = await request.get('/e2e/helpers/final_score_setup.php');
+        const body = await res.json();
+        if (body.error) throw new Error(`Setup failed: ${body.error}`);
+        expect(res.status()).toBe(200);
+        expect(body.success).toBe(true);
+        codeScored = body.code_scored;
+        codeUnscored = body.code_unscored;
+    });
+
+    test.afterAll(async ({ request }) => {
+        await request.get('/e2e/helpers/final_score_teardown.php');
+        codeScored = null;
+        codeUnscored = null;
+    });
+
+    test('Matchs du jour : score final affiché seulement si renseigné', async ({ page }) => {
+        await page.goto('/pages/home.html#/home');
+        await expect(page.getByText('Matchs du jour')).toBeVisible({ timeout: 10000 });
+
+        const scoredCard = page.locator(`a[href="/live.html?id_match=${codeScored}"]`);
+        const unscoredCard = page.locator(`a[href="/live.html?id_match=${codeUnscored}"]`);
+
+        await expect(scoredCard).toBeVisible();
+        await expect(unscoredCard).toBeVisible();
+
+        // Match avec score : affiche "3 - 0" et pas "vs"
+        await expect(scoredCard).toContainText('3 - 0');
+        await expect(scoredCard).not.toContainText('vs');
+
+        // Match sans score : affiche "vs" et aucun score
+        await expect(unscoredCard).toContainText('vs');
+        await expect(unscoredCard).not.toContainText('3 - 0');
+
+        await page.screenshot({ path: 'test-results/issue-235/home_today_matches_score.png', fullPage: true });
+    });
+
+    test('live.html (match avec score) : bouton scoreur masqué + résultat final', async ({ page }) => {
+        await page.goto(`/live.html?id_match=${codeScored}`);
+
+        // Le score final est affiché
+        await expect(page.getByText('Résultat final')).toBeVisible({ timeout: 10000 });
+
+        // Le bouton "Passer en mode scoreur" est masqué
+        await expect(page.getByRole('button', { name: /Passer en mode scoreur/ })).toHaveCount(0);
+
+        await page.screenshot({ path: 'test-results/issue-235/live_scored.png', fullPage: true });
+    });
+
+    test('live.html (match sans score) : bouton scoreur visible, pas de résultat final', async ({ page }) => {
+        await page.goto(`/live.html?id_match=${codeUnscored}`);
+
+        // Le bouton "Passer en mode scoreur" est visible
+        await expect(page.getByRole('button', { name: /Passer en mode scoreur/ })).toBeVisible({ timeout: 10000 });
+
+        // Aucun "Résultat final"
+        await expect(page.getByText('Résultat final')).toHaveCount(0);
+
+        await page.screenshot({ path: 'test-results/issue-235/live_unscored.png', fullPage: true });
+    });
+});

--- a/live.html
+++ b/live.html
@@ -36,18 +36,37 @@
                 <span class="badge badge-outline ml-2">Division {{ match.division }}</span>
             </div>
 
+            <!-- Score final (match terminé) : affiché dès que is_match_score_filled
+                 vaut 1. C'est le score FINAL (sets gagnés), pas le live score. -->
+            <div class="card bg-base-100 shadow-md border border-base-300 mb-4" v-if="isMatchFinished">
+                <div class="card-body p-4">
+                    <div class="text-center text-sm font-semibold opacity-60 mb-2">
+                        <i class="fas fa-flag-checkered mr-1"></i>Résultat final
+                    </div>
+                    <div class="flex items-center justify-center gap-4 text-center">
+                        <span class="flex-1 text-right font-bold">{{ match.equipe_dom }}</span>
+                        <span class="text-3xl font-mono font-bold">{{ match.score_equipe_dom }} - {{ match.score_equipe_ext }}</span>
+                        <span class="flex-1 text-left font-bold">{{ match.equipe_ext }}</span>
+                    </div>
+                </div>
+            </div>
+
             <!-- Passer en mode scoreur — visible publiquement pour faire découvrir
                  la fonctionnalité. L'accès réel reste réservé aux responsables des 2
-                 équipes et aux admins : c'est goToScorerMode() qui aiguille au clic. -->
-            <div class="text-center mb-4" v-if="!isScorer">
+                 équipes et aux admins : c'est goToScorerMode() qui aiguille au clic.
+                 Masqué quand le match est terminé (score final renseigné). -->
+            <div class="text-center mb-4" v-if="!isScorer && !isMatchFinished">
                 <button @click="goToScorerMode" type="button"
                         class="btn btn-warning btn-sm animate-pulse">
                     <i class="fas fa-edit mr-1"></i>Passer en mode scoreur
                 </button>
             </div>
 
-            <!-- Score Board -->
+            <!-- Score Board (live) — masqué pour un match terminé en simple
+                 consultation : le bloc "Résultat final" ci-dessus le remplace.
+                 Reste visible en mode scoreur ou pendant un live en cours. -->
             <score-board
+                v-if="isScorer || isLive || !isMatchFinished"
                 :score="score"
                 :left-team-name="leftTeamName"
                 :right-team-name="rightTeamName"
@@ -104,7 +123,7 @@
             </template>
 
             <!-- Status Messages -->
-            <div class="alert alert-info mb-4" v-if="!isLive && !isScorer">
+            <div class="alert alert-info mb-4" v-if="!isLive && !isScorer && !isMatchFinished">
                 <i class="fas fa-info-circle"></i>
                 <span>Le live score n'est pas encore démarré pour ce match.</span>
             </div>

--- a/live.js
+++ b/live.js
@@ -122,6 +122,12 @@ createApp({
         },
         localStorageKey() {
             return 'live_score_draft_' + this.idMatch;
+        },
+        // Score FINAL renseigné (match terminé) : is_match_score_filled vaut 1
+        // dès qu'une équipe a gagné 3 sets. Peut arriver en chaîne ("0"/"1") via
+        // mysqli → comparaison souple ("0" est truthy en JS).
+        isMatchFinished() {
+            return this.match != null && this.match.is_match_score_filled == 1;
         }
     },
     async mounted() {

--- a/pages/components/panel/TodayMatches.js
+++ b/pages/components/panel/TodayMatches.js
@@ -23,7 +23,8 @@ export default {
               </div>
               <div class="flex items-center justify-center gap-2 text-center font-bold text-base my-1">
                 <span class="flex-1 text-right">{{ match.equipe_dom }}</span>
-                <span class="opacity-50">vs</span>
+                <span v-if="isScoreFilled(match)" class="font-mono text-primary">{{ match.score_equipe_dom }} - {{ match.score_equipe_ext }}</span>
+                <span v-else class="opacity-50">vs</span>
                 <span class="flex-1 text-left">{{ match.equipe_ext }}</span>
               </div>
               <div class="flex items-center justify-between gap-2 text-xs opacity-70">
@@ -43,6 +44,12 @@ export default {
         };
     },
     methods: {
+        // Score FINAL renseigné (match terminé) — pas le live score.
+        // is_match_score_filled peut arriver en chaîne ("0"/"1") via mysqli :
+        // on compare en souple pour éviter que "0" (truthy en JS) ne passe.
+        isScoreFilled(match) {
+            return match.is_match_score_filled == 1;
+        },
         formatHeure(heure) {
             // "20:30:00" -> "20:30"
             if (!heure) {


### PR DESCRIPTION
## Description
Résout #235

Affiche le **score final** d'un match (nombre de sets) **lorsqu'il est renseigné** (`is_match_score_filled == 1`), à deux endroits. On s'appuie sur le score final, **jamais** sur le live score.

## Changements

### Partie A — encart « Matchs du jour » (page d'accueil)
- `MatchMgr::getMatchesOfTheDay()` : ajout de `is_match_score_filled` à la whitelist (les sets `score_equipe_dom/ext` étaient déjà exposés).
- `TodayMatches.js` : affiche `score_equipe_dom - score_equipe_ext` si renseigné, sinon « vs ».

### Partie B — page `live.html`
- `live.js` : computed `isMatchFinished` (`is_match_score_filled == 1`, comparaison souple car mysqli renvoie `"0"`/`"1"`).
- `live.html` :
  - masque le bouton « Passer en mode scoreur » quand le match est terminé ;
  - affiche un bloc **« Résultat final »** (équipes + score en sets) ;
  - masque le `ScoreBoard` live (0-0) et le message « live pas démarré » en simple consultation d'un match terminé (le résultat final les remplace) ; le board reste visible en mode scoreur ou pendant un live.

## Tests
- [x] Test E2E Playwright `e2e/tests/issue_235.spec.js` (3 cas) — `3 passed` :
  - Matchs du jour : score affiché si renseigné, « vs » sinon
  - live.html (match avec score) : bouton scoreur masqué + « Résultat final »
  - live.html (match sans score) : bouton visible, pas de résultat final
- [x] Helpers `final_score_setup.php` / `final_score_teardown.php` (un match du jour 3-0, un sans score)
- [x] Screenshots de preuve dans `e2e/test-results/issue-235/`
- [x] Régression : `home_today_matches.spec.js` + `live_score.spec.js` → `3 passed`
- N/A Tests unitaires PHP (changement backend = 1 champ ajouté à une whitelist, couvert par l'E2E)

## Checklist
- [ ] Code review demandée
- [x] Pas de changement de schéma / pas de doc à mettre à jour
