### PR TITLE
Fix #240: Toasts d'actions en attente pour le responsable d'équipe

### DIFF
--- a/classes/MatchMgr.php
+++ b/classes/MatchMgr.php
@@ -200,7 +200,8 @@ class MatchMgr extends Generic
 
     /**
      * Actions en attente du responsable connecté, pour ses matchs déjà joués
-     * (date <= aujourd'hui). Un élément par match, avec sa prochaine action.
+     * (date <= aujourd'hui) et NON encore certifiés par la commission.
+     * Un élément par match, avec sa prochaine action.
      * Utilisé pour afficher des toasts à la connexion (issue #240).
      *
      * @return array
@@ -217,6 +218,7 @@ class MatchMgr extends Generic
         $matches = $this->get_matches(
             "(m.id_equipe_dom = $team_id OR m.id_equipe_ext = $team_id)
                     AND m.match_status NOT IN ('ARCHIVED')
+                    AND m.certif = 0
                     AND STR_TO_DATE(m.date_reception, '%d/%m/%Y') <= CURDATE()");
         $result = array();
         foreach ($matches as $match) {

--- a/classes/MatchMgr.php
+++ b/classes/MatchMgr.php
@@ -158,8 +158,86 @@ class MatchMgr extends Generic
         @session_start();
         $team_id = $_SESSION['id_equipe'];
         return $this->get_matches(
-            "(m.id_equipe_dom = $team_id OR m.id_equipe_ext = $team_id) 
+            "(m.id_equipe_dom = $team_id OR m.id_equipe_ext = $team_id)
                     AND m.match_status NOT IN ('ARCHIVED')");
+    }
+
+    /**
+     * Détermine la PROCHAINE action en attente pour un camp donné d'un match,
+     * dans l'ordre du workflow : présents -> signer fiche -> score -> signer feuille -> sondage.
+     * Reproduit la logique d'affichage de pages/components/match/MatchSummary.js.
+     *
+     * @param array $match Une ligne de matchs_view
+     * @param string $side 'dom' ou 'ext'
+     * @return array|null ['action','label','url'] ou null si plus rien à faire
+     */
+    public function getNextMatchActionForSide(array $match, string $side): ?array
+    {
+        $id = $match['id_match'];
+        $playerFilled = (int)($match['is_match_player_filled'] ?? 0) === 1;
+        $signTeam = (int)($match['is_sign_team_' . $side] ?? 0) === 1;
+        $scoreFilled = (int)($match['is_match_score_filled'] ?? 0) === 1;
+        $signMatch = (int)($match['is_sign_match_' . $side] ?? 0) === 1;
+        $surveyFilled = (int)($match['is_survey_filled_' . $side] ?? 0) === 1;
+
+        if (!$playerFilled) {
+            return ['action' => 'fill_players', 'label' => 'Remplir les joueurs présents', 'url' => '/team_sheets.html?id_match=' . $id];
+        }
+        if (!$signTeam) {
+            return ['action' => 'sign_team', 'label' => 'Signer la fiche équipe', 'url' => '/team_sheets.html?id_match=' . $id];
+        }
+        if (!$scoreFilled) {
+            return ['action' => 'fill_score', 'label' => 'Remplir le score', 'url' => '/match.html?id_match=' . $id];
+        }
+        if (!$signMatch) {
+            return ['action' => 'sign_match', 'label' => 'Signer la feuille de match', 'url' => '/match.html?id_match=' . $id];
+        }
+        if (!$surveyFilled) {
+            return ['action' => 'fill_survey', 'label' => 'Remplir le sondage', 'url' => '/survey.html?id_match=' . $id];
+        }
+        return null;
+    }
+
+    /**
+     * Actions en attente du responsable connecté, pour ses matchs déjà joués
+     * (date <= aujourd'hui). Un élément par match, avec sa prochaine action.
+     * Utilisé pour afficher des toasts à la connexion (issue #240).
+     *
+     * @return array
+     * @throws Exception
+     */
+    public function getMyPendingMatchActions(): array
+    {
+        @session_start();
+        $team_id = $_SESSION['id_equipe'] ?? null;
+        if (empty($team_id) || !is_numeric($team_id)) {
+            return [];
+        }
+        $team_id = (int)$team_id;
+        $matches = $this->get_matches(
+            "(m.id_equipe_dom = $team_id OR m.id_equipe_ext = $team_id)
+                    AND m.match_status NOT IN ('ARCHIVED')
+                    AND STR_TO_DATE(m.date_reception, '%d/%m/%Y') <= CURDATE()");
+        $result = array();
+        foreach ($matches as $match) {
+            $side = ((int)$match['id_equipe_dom'] === $team_id) ? 'dom' : 'ext';
+            $action = $this->getNextMatchActionForSide($match, $side);
+            if ($action === null) {
+                continue;
+            }
+            $result[] = array(
+                'id_match' => $match['id_match'],
+                'code_match' => $match['code_match'],
+                'libelle_competition' => $match['libelle_competition'],
+                'division' => $match['division'],
+                'date_reception' => $match['date_reception'],
+                'equipe_adverse' => $side === 'dom' ? $match['equipe_ext'] : $match['equipe_dom'],
+                'action' => $action['action'],
+                'label' => $action['label'],
+                'url' => $action['url'],
+            );
+        }
+        return $result;
     }
 
     /**

--- a/classes/MatchMgr.php
+++ b/classes/MatchMgr.php
@@ -169,18 +169,20 @@ class MatchMgr extends Generic
      *
      * @param array $match Une ligne de matchs_view
      * @param string $side 'dom' ou 'ext'
+     * @param bool $presentsFilled Les joueurs présents de ce camp sont-ils saisis ?
+     *        (à calculer par l'appelant : is_match_player_filled de matchs_view n'est
+     *        PAS fiable côté camp — il vaut 1 même pour un état d'erreur "fiche non remplie".)
      * @return array|null ['action','label','url'] ou null si plus rien à faire
      */
-    public function getNextMatchActionForSide(array $match, string $side): ?array
+    public function getNextMatchActionForSide(array $match, string $side, bool $presentsFilled): ?array
     {
         $id = $match['id_match'];
-        $playerFilled = (int)($match['is_match_player_filled'] ?? 0) === 1;
         $signTeam = (int)($match['is_sign_team_' . $side] ?? 0) === 1;
         $scoreFilled = (int)($match['is_match_score_filled'] ?? 0) === 1;
         $signMatch = (int)($match['is_sign_match_' . $side] ?? 0) === 1;
         $surveyFilled = (int)($match['is_survey_filled_' . $side] ?? 0) === 1;
 
-        if (!$playerFilled) {
+        if (!$presentsFilled) {
             return ['action' => 'fill_players', 'label' => 'Remplir les joueurs présents', 'url' => '/team_sheets.html?id_match=' . $id];
         }
         if (!$signTeam) {
@@ -220,10 +222,28 @@ class MatchMgr extends Generic
                     AND m.match_status NOT IN ('ARCHIVED')
                     AND m.certif = 0
                     AND STR_TO_DATE(m.date_reception, '%d/%m/%Y') <= CURDATE()");
+        if (empty($matches)) {
+            return array();
+        }
+        // Matchs où l'équipe du responsable a déjà saisi des joueurs présents
+        // (indicateur fiable par camp, contrairement à is_match_player_filled).
+        $ids = array_map(static fn($m) => (int)$m['id_match'], $matches);
+        $idList = implode(',', $ids);
+        $filledRows = $this->sql_manager->execute(
+            "SELECT DISTINCT mp.id_match
+             FROM match_player mp
+             JOIN joueur_equipe je ON je.id_joueur = mp.id_player
+             WHERE je.id_equipe = $team_id AND mp.id_match IN ($idList)");
+        $presentsByMatch = array();
+        foreach ($filledRows as $row) {
+            $presentsByMatch[(int)$row['id_match']] = true;
+        }
+
         $result = array();
         foreach ($matches as $match) {
             $side = ((int)$match['id_equipe_dom'] === $team_id) ? 'dom' : 'ext';
-            $action = $this->getNextMatchActionForSide($match, $side);
+            $presentsFilled = isset($presentsByMatch[(int)$match['id_match']]);
+            $action = $this->getNextMatchActionForSide($match, $side, $presentsFilled);
             if ($action === null) {
                 continue;
             }

--- a/e2e/helpers/match_actions_setup.php
+++ b/e2e/helpers/match_actions_setup.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * E2E test helper (#240) — ouvre une session responsable d'équipe et crée un
+ * match DÉJÀ JOUÉ (date passée) sans aucune donnée saisie, de sorte qu'une
+ * action soit en attente ("Remplir les joueurs présents") et qu'un toast
+ * apparaisse à la connexion.
+ *
+ * On recopie les FK d'un match déjà visible dans matchs_view (cf.
+ * today_matches_setup.php) pour que la ligne insérée remonte bien dans la vue.
+ *
+ * Returns JSON: { success, id_match, code_match, id_equipe, equipe_adverse, expected_label }
+ *
+ * SECURITY: ne doit jamais être déployé en production.
+ */
+$isLocalhost = in_array($_SERVER['REMOTE_ADDR'] ?? '', ['127.0.0.1', '::1'], true);
+$isTestEnv   = getenv('APP_ENV') === 'test';
+if (!$isLocalhost && !$isTestEnv) {
+    http_response_code(403);
+    exit('Forbidden');
+}
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../classes/SqlManager.php';
+require_once __DIR__ . '/../../classes/MatchMgr.php';
+
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/../../');
+$dotenv->load();
+
+header('Content-Type: application/json');
+
+try {
+    $sql = new SqlManager();
+
+    // Nettoyage préventif (préfixe court : code_match est en VARCHAR(20))
+    $sql->execute("DELETE FROM matches WHERE code_match LIKE 'E2A%'");
+
+    // Échantillon depuis matchs_view => FK valides garanties (jointures INNER OK).
+    $sample = $sql->execute(
+        "SELECT code_competition, division, id_equipe_dom, id_equipe_ext, id_gymnasium, id_journee
+         FROM matchs_view
+         LIMIT 1"
+    );
+    if (empty($sample)) {
+        throw new Exception("Aucun match modèle dans matchs_view en base de test.");
+    }
+    $s = $sample[0];
+
+    $code_match = 'E2A' . date('ymdHis'); // 3 + 12 = 15 car. (<= VARCHAR(20))
+    $hasGym = !empty($s['id_gymnasium']);
+    $gymClause = $hasGym ? "id_gymnasium = ?," : "";
+
+    $bindings = [
+        ['type' => 's', 'value' => $code_match],
+        ['type' => 's', 'value' => $s['code_competition']],
+        ['type' => 's', 'value' => $s['division']],
+        ['type' => 'i', 'value' => (int)$s['id_equipe_dom']],
+        ['type' => 'i', 'value' => (int)$s['id_equipe_ext']],
+    ];
+    if ($hasGym) {
+        $bindings[] = ['type' => 'i', 'value' => (int)$s['id_gymnasium']];
+    }
+
+    // Match daté d'il y a 7 jours, sans score/joueurs/signatures => action en attente.
+    $id_match = $sql->execute(
+        "INSERT INTO matches SET
+            code_match       = ?,
+            code_competition = ?,
+            division         = ?,
+            id_equipe_dom    = ?,
+            id_equipe_ext    = ?,
+            $gymClause
+            date_reception   = CURRENT_DATE - INTERVAL 7 DAY,
+            date_original    = CURRENT_DATE - INTERVAL 7 DAY,
+            match_status     = 'CONFIRMED'",
+        $bindings
+    );
+
+    $id_equipe = (int)$s['id_equipe_dom'];
+
+    // Calcule la VRAIE prochaine action attendue (selon l'état réel dans matchs_view),
+    // pour que le test cible le bon libellé sans présumer du comportement de la vue.
+    $rows = (new MatchMgr())->get_matches("m.code_match = '$code_match'");
+    if (empty($rows)) {
+        throw new Exception("Le match de test n'apparaît pas dans matchs_view.");
+    }
+    $row = $rows[0];
+    $equipe_adverse = $row['equipe_ext'];
+    $action = (new MatchMgr())->getNextMatchActionForSide($row, 'dom');
+    if ($action === null) {
+        throw new Exception("Le match de test n'a aucune action en attente (état inattendu).");
+    }
+
+    // Ouvrir une session "responsable" de l'équipe dom (profil admin pour
+    // contourner les vérifications d'équipe, comme messages_setup.php).
+    // La session peut déjà être active (démarrée par MatchMgr/Generic) : on évite
+    // alors un Notice qui casserait le JSON renvoyé.
+    if (session_status() !== PHP_SESSION_ACTIVE) {
+        session_start();
+    }
+    $_SESSION['profile_name'] = 'ADMINISTRATEUR';
+    $_SESSION['login']        = 'e2e_test';
+    $_SESSION['id_user']      = 1;
+    $_SESSION['id_equipe']    = $id_equipe;
+
+    echo json_encode([
+        'success'        => true,
+        'id_match'       => (int)$id_match,
+        'code_match'     => $code_match,
+        'id_equipe'      => $id_equipe,
+        'equipe_adverse' => $equipe_adverse,
+        'expected_action' => $action['action'],
+        'expected_label' => $action['label'],
+        'expected_url'   => $action['url'],
+        'session_id'     => session_id(),
+    ]);
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}

--- a/e2e/helpers/match_actions_setup.php
+++ b/e2e/helpers/match_actions_setup.php
@@ -85,7 +85,15 @@ try {
     }
     $row = $rows[0];
     $equipe_adverse = $row['equipe_ext'];
-    $action = (new MatchMgr())->getNextMatchActionForSide($row, 'dom');
+    // Présents saisis ? (match neuf => aucun match_player => false)
+    $cnt = $sql->execute(
+        "SELECT COUNT(*) AS c FROM match_player mp
+         JOIN joueur_equipe je ON je.id_joueur = mp.id_player
+         WHERE mp.id_match = ? AND je.id_equipe = ?",
+        [['type' => 'i', 'value' => (int)$row['id_match']], ['type' => 'i', 'value' => $id_equipe]]
+    );
+    $presentsFilled = ((int)($cnt[0]['c'] ?? 0)) > 0;
+    $action = (new MatchMgr())->getNextMatchActionForSide($row, 'dom', $presentsFilled);
     if ($action === null) {
         throw new Exception("Le match de test n'a aucune action en attente (état inattendu).");
     }

--- a/e2e/helpers/match_actions_teardown.php
+++ b/e2e/helpers/match_actions_teardown.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * E2E test helper (#240) — supprime le match de test créé par
+ * match_actions_setup.php.
+ *
+ * SECURITY: ne doit jamais être déployé en production.
+ */
+$isLocalhost = in_array($_SERVER['REMOTE_ADDR'] ?? '', ['127.0.0.1', '::1'], true);
+$isTestEnv   = getenv('APP_ENV') === 'test';
+if (!$isLocalhost && !$isTestEnv) {
+    http_response_code(403);
+    exit('Forbidden');
+}
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../classes/SqlManager.php';
+
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/../../');
+$dotenv->load();
+
+header('Content-Type: application/json');
+
+try {
+    $sql = new SqlManager();
+    $sql->execute("DELETE FROM matches WHERE code_match LIKE 'E2A%'");
+    echo json_encode(['success' => true]);
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}

--- a/e2e/tests/issue_240.spec.js
+++ b/e2e/tests/issue_240.spec.js
@@ -1,0 +1,53 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+/**
+ * E2E — Toasts d'actions en attente pour le responsable d'équipe (issue #240)
+ *
+ * Setup : ouvre une session responsable + crée un match déjà joué (date passée)
+ * sans données saisies => une action est en attente ("Remplir les joueurs présents").
+ * On vérifie qu'un toast apparaît à la connexion (espace responsable ET home
+ * publique), et qu'un clic mène à la page de l'action.
+ */
+test.describe("Issue #240 — Toasts actions en attente (responsable)", () => {
+    let setup = null;
+
+    test.beforeEach(async ({ page }) => {
+        // Le goto() permet à PHP de poser le cookie PHPSESSID via Set-Cookie
+        await page.goto('/e2e/helpers/match_actions_setup.php');
+        const body = JSON.parse(await page.locator('body').innerText());
+        if (body.error) throw new Error(`Setup failed: ${body.error}`);
+        setup = body;
+    });
+
+    test.afterEach(async ({ page }) => {
+        await page.request.get('/e2e/helpers/match_actions_teardown.php');
+        setup = null;
+    });
+
+    test("un toast d'action en attente apparaît sur l'espace responsable", async ({ page }) => {
+        await page.goto('/pages/my_page.html');
+        // Le toast contient l'équipe adverse + le libellé de l'action en attente
+        const toast = page.locator('.toastify').filter({ hasText: setup.equipe_adverse });
+        await expect(toast.first()).toBeVisible({ timeout: 10000 });
+        await expect(toast.first()).toContainText(setup.expected_label);
+        await page.screenshot({ path: 'test-results/issue-240/toast_my_page.png', fullPage: true });
+    });
+
+    test("le toast apparaît aussi sur la page d'accueil publique", async ({ page }) => {
+        await page.goto('/pages/home.html');
+        const toast = page.locator('.toastify').filter({ hasText: setup.equipe_adverse });
+        await expect(toast.first()).toBeVisible({ timeout: 10000 });
+        await page.screenshot({ path: 'test-results/issue-240/toast_home.png', fullPage: true });
+    });
+
+    test("cliquer le toast mène à la page de l'action", async ({ page }) => {
+        await page.goto('/pages/my_page.html');
+        const toast = page.locator('.toastify').filter({ hasText: setup.equipe_adverse }).first();
+        await expect(toast).toBeVisible({ timeout: 10000 });
+        await toast.click();
+        // Le clic ouvre la page de l'action (team_sheets / match / survey) du bon match
+        await expect(page).toHaveURL(new RegExp('(team_sheets|match|survey)\\.html\\?id_match=' + setup.id_match), { timeout: 10000 });
+        await page.screenshot({ path: 'test-results/issue-240/toast_click_navigates.png', fullPage: true });
+    });
+});

--- a/pages/components/notifications/matchActionToasts.js
+++ b/pages/components/notifications/matchActionToasts.js
@@ -1,0 +1,31 @@
+// Issue #240 — Affiche un toast par match déjà joué ayant une action en attente
+// pour le responsable d'équipe connecté (présents, signatures, score, sondage).
+// Appelé après le montage de l'app sur la home publique ET l'espace responsable.
+//
+// L'endpoint renvoie [] si l'utilisateur n'est pas connecté en responsable
+// (pas d'id_equipe en session) : aucun toast pour les visiteurs anonymes.
+export async function showMatchActionToasts() {
+    try {
+        const response = await window.axios.get('/rest/action.php/matchmgr/getMyPendingMatchActions');
+        const items = response.data;
+        if (!Array.isArray(items) || items.length === 0) {
+            return;
+        }
+        items.forEach((item) => {
+            window.Toastify({
+                text: `📋 ${item.equipe_adverse} (D${item.division}) — ${item.label}`,
+                duration: -1,          // reste affiché jusqu'à fermeture/clic
+                close: true,
+                gravity: 'top',
+                position: 'right',
+                stopOnFocus: true,
+                style: { background: '#2563eb', cursor: 'pointer' },
+                onClick: () => {
+                    window.location.href = item.url;
+                },
+            }).showToast();
+        });
+    } catch (e) {
+        // non connecté ou erreur réseau : pas de notification
+    }
+}

--- a/pages/home.js
+++ b/pages/home.js
@@ -4,6 +4,7 @@ import axios from 'axios';
 import Toastify from 'toastify-js';
 import { Notyf } from 'notyf';
 import AppLayout from './components/layout/AppLayout.js';
+import { showMatchActionToasts } from './components/notifications/matchActionToasts.js';
 
 // Expose les libs en global pour les sous-composants qui les utilisent sans import
 window.axios = axios;
@@ -14,3 +15,6 @@ window.Notyf = Notyf;
 const app = createApp(AppLayout);
 app.use(AppLayout.router);
 app.mount('#app');
+
+// Notifications (toasts) des actions en attente pour le responsable connecté (#240)
+showMatchActionToasts();

--- a/pages/my_page.js
+++ b/pages/my_page.js
@@ -4,6 +4,7 @@ import axios from 'axios';
 import Toastify from 'toastify-js';
 import { Notyf } from 'notyf';
 import TeamLeaderLayout from './components/layout/TeamLeaderLayout.js';
+import { showMatchActionToasts } from './components/notifications/matchActionToasts.js';
 
 window.axios = axios;
 window.Toastify = Toastify;
@@ -13,3 +14,6 @@ window.Notyf = Notyf;
 const app = createApp(TeamLeaderLayout);
 app.use(TeamLeaderLayout.router);
 app.mount('#app');
+
+// Notifications (toasts) des actions en attente pour le responsable connecté (#240)
+showMatchActionToasts();

--- a/unit_tests/MatchManagerTest.php
+++ b/unit_tests/MatchManagerTest.php
@@ -161,6 +161,55 @@ class MatchManagerTest extends UfolepTestCase
     /**
      * @throws Exception
      */
+    /**
+     * Issue #240 — la prochaine action en attente suit le workflow :
+     * présents -> signer fiche -> score -> signer feuille -> sondage, et chaque
+     * camp (dom/ext) est résolu indépendamment.
+     */
+    public function test_getNextMatchActionForSide_workflow_order(): void
+    {
+        $base = array(
+            'id_match' => 'UT_1',
+            'is_match_player_filled' => 0,
+            'is_sign_team_dom' => 0, 'is_sign_team_ext' => 0,
+            'is_match_score_filled' => 0,
+            'is_sign_match_dom' => 0, 'is_sign_match_ext' => 0,
+            'is_survey_filled_dom' => 0, 'is_survey_filled_ext' => 0,
+        );
+
+        // 1) Rien de fait -> remplir les présents (team_sheets)
+        $a = $this->match_manager->getNextMatchActionForSide($base, 'dom');
+        $this->assertEquals('fill_players', $a['action']);
+        $this->assertStringContainsString('/team_sheets.html?id_match=UT_1', $a['url']);
+
+        // 2) Présents remplis -> signer la fiche équipe
+        $m = array_merge($base, array('is_match_player_filled' => 1));
+        $this->assertEquals('sign_team', $this->match_manager->getNextMatchActionForSide($m, 'dom')['action']);
+
+        // 3) Fiche signée -> remplir le score (match.html)
+        $m = array_merge($m, array('is_sign_team_dom' => 1));
+        $a = $this->match_manager->getNextMatchActionForSide($m, 'dom');
+        $this->assertEquals('fill_score', $a['action']);
+        $this->assertStringContainsString('/match.html?id_match=UT_1', $a['url']);
+
+        // 4) Score rempli -> signer la feuille de match
+        $m = array_merge($m, array('is_match_score_filled' => 1));
+        $this->assertEquals('sign_match', $this->match_manager->getNextMatchActionForSide($m, 'dom')['action']);
+
+        // 5) Feuille signée -> remplir le sondage (survey.html)
+        $m = array_merge($m, array('is_sign_match_dom' => 1));
+        $a = $this->match_manager->getNextMatchActionForSide($m, 'dom');
+        $this->assertEquals('fill_survey', $a['action']);
+        $this->assertStringContainsString('/survey.html?id_match=UT_1', $a['url']);
+
+        // 6) Tout fait pour dom -> plus d'action
+        $m = array_merge($m, array('is_survey_filled_dom' => 1));
+        $this->assertNull($this->match_manager->getNextMatchActionForSide($m, 'dom'));
+
+        // 7) Le camp ext est indépendant : présents partagés OK, mais ext n'a rien signé
+        $this->assertEquals('sign_team', $this->match_manager->getNextMatchActionForSide($m, 'ext')['action']);
+    }
+
     protected function setUp(): void
     {
         parent::setUp();

--- a/unit_tests/MatchManagerTest.php
+++ b/unit_tests/MatchManagerTest.php
@@ -170,44 +170,42 @@ class MatchManagerTest extends UfolepTestCase
     {
         $base = array(
             'id_match' => 'UT_1',
-            'is_match_player_filled' => 0,
             'is_sign_team_dom' => 0, 'is_sign_team_ext' => 0,
             'is_match_score_filled' => 0,
             'is_sign_match_dom' => 0, 'is_sign_match_ext' => 0,
             'is_survey_filled_dom' => 0, 'is_survey_filled_ext' => 0,
         );
 
-        // 1) Rien de fait -> remplir les présents (team_sheets)
-        $a = $this->match_manager->getNextMatchActionForSide($base, 'dom');
+        // 1) Présents NON remplis -> remplir les présents (team_sheets)
+        $a = $this->match_manager->getNextMatchActionForSide($base, 'dom', false);
         $this->assertEquals('fill_players', $a['action']);
         $this->assertStringContainsString('/team_sheets.html?id_match=UT_1', $a['url']);
 
         // 2) Présents remplis -> signer la fiche équipe
-        $m = array_merge($base, array('is_match_player_filled' => 1));
-        $this->assertEquals('sign_team', $this->match_manager->getNextMatchActionForSide($m, 'dom')['action']);
+        $this->assertEquals('sign_team', $this->match_manager->getNextMatchActionForSide($base, 'dom', true)['action']);
 
         // 3) Fiche signée -> remplir le score (match.html)
-        $m = array_merge($m, array('is_sign_team_dom' => 1));
-        $a = $this->match_manager->getNextMatchActionForSide($m, 'dom');
+        $m = array_merge($base, array('is_sign_team_dom' => 1));
+        $a = $this->match_manager->getNextMatchActionForSide($m, 'dom', true);
         $this->assertEquals('fill_score', $a['action']);
         $this->assertStringContainsString('/match.html?id_match=UT_1', $a['url']);
 
         // 4) Score rempli -> signer la feuille de match
         $m = array_merge($m, array('is_match_score_filled' => 1));
-        $this->assertEquals('sign_match', $this->match_manager->getNextMatchActionForSide($m, 'dom')['action']);
+        $this->assertEquals('sign_match', $this->match_manager->getNextMatchActionForSide($m, 'dom', true)['action']);
 
         // 5) Feuille signée -> remplir le sondage (survey.html)
         $m = array_merge($m, array('is_sign_match_dom' => 1));
-        $a = $this->match_manager->getNextMatchActionForSide($m, 'dom');
+        $a = $this->match_manager->getNextMatchActionForSide($m, 'dom', true);
         $this->assertEquals('fill_survey', $a['action']);
         $this->assertStringContainsString('/survey.html?id_match=UT_1', $a['url']);
 
         // 6) Tout fait pour dom -> plus d'action
         $m = array_merge($m, array('is_survey_filled_dom' => 1));
-        $this->assertNull($this->match_manager->getNextMatchActionForSide($m, 'dom'));
+        $this->assertNull($this->match_manager->getNextMatchActionForSide($m, 'dom', true));
 
-        // 7) Le camp ext est indépendant : présents partagés OK, mais ext n'a rien signé
-        $this->assertEquals('sign_team', $this->match_manager->getNextMatchActionForSide($m, 'ext')['action']);
+        // 7) Le camp ext est indépendant : présents remplis mais ext n'a rien signé
+        $this->assertEquals('sign_team', $this->match_manager->getNextMatchActionForSide($m, 'ext', true)['action']);
     }
 
     protected function setUp(): void


### PR DESCRIPTION
## Description
Résout #240 — notifications **toasts** des actions en attente pour le responsable d'équipe, à la connexion, sans navigation.

## Comportement
- À la connexion (sur la **home publique** ET l'**espace responsable**), un **toast par match déjà joué** (`date_reception <= aujourd'hui`) ayant une action en attente.
- Le toast affiche l'équipe adverse + la **prochaine action** à faire et pointe (clic) vers la page correspondante.
- Ordre des actions : présents → signer fiche → score → signer feuille → sondage (aligné sur `MatchSummary.js`).
- Toasts persistants jusqu'à fermeture/clic. Endpoint sûr (renvoie `[]` si pas de responsable connecté).

## Changements
- **Backend** `classes/MatchMgr.php` :
  - `getMyPendingMatchActions()` — matchs joués du responsable + prochaine action par camp.
  - `getNextMatchActionForSide()` — logique d'ordre (pure, testable).
- **Frontend** : `pages/components/notifications/matchActionToasts.js` + branchement dans `pages/home.js` et `pages/my_page.js`.

## Tests
- [x] Test unitaire PHPUnit : ordre des actions (`MatchManagerTest::test_getNextMatchActionForSide_workflow_order`) — vert.
- [x] Test E2E Playwright `e2e/tests/issue_240.spec.js` (3 tests verts) avec helpers `match_actions_setup/teardown.php` (session responsable + match de test joué).
- [x] Screenshots de preuve dans `e2e/test-results/issue-240/`.

## Checklist
- [ ] Code review
- [ ] Scénario rejoué manuellement par le responsable du projet

🤖 Generated with [Claude Code](https://claude.com/claude-code)
