### PR TITLE
Feature #101: pouvoirs du compte RESPONSABLE_CLUB (gestion club + agir en tant que)

### DIFF
--- a/classes/BlackListCourt.php
+++ b/classes/BlackListCourt.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . "/Generic.php";
+require_once __DIR__ . "/Club.php";
 
 class BlackListCourt extends Generic
 {
@@ -66,6 +67,13 @@ class BlackListCourt extends Generic
      * @throws Exception
      */
     public function saveBlacklistGymnase($id_gymnase, $closed_date, $dirtyFields=null, $id=null) {
+        // Un responsable de club ne peut fermer qu'un gymnase utilisé par son club.
+        if (!UserManager::isAdmin()) {
+            if (!UserManager::isClubLeader()) {
+                throw new Exception("Vous n'êtes pas autorisé à effectuer cette action !", 403);
+            }
+            $this->assertClubGymnasium($id_gymnase);
+        }
         $inputs = array(
             'id_gymnase' => $id_gymnase,
             'closed_date' => $closed_date,
@@ -73,6 +81,83 @@ class BlackListCourt extends Generic
             'id' => $id,
         );
         return $this->save($inputs);
+    }
+
+    /**
+     * Gymnases utilisés par les équipes du club du responsable connecté
+     * (via leurs créneaux). Sert au sélecteur de fermetures.
+     * @throws Exception
+     */
+    public function getMyClubGymnasiums(): array
+    {
+        $id_club = (new Club())->getMyClubId();
+        $sql = "SELECT DISTINCT
+                    g.id,
+                    CONCAT(g.nom, ' (', g.ville, ')') AS full_name
+                FROM creneau cr
+                JOIN equipes e ON e.id_equipe = cr.id_equipe
+                JOIN gymnase g ON g.id = cr.id_gymnase
+                WHERE e.id_club = ?
+                ORDER BY full_name";
+        $bindings = array(array('type' => 'i', 'value' => $id_club));
+        return $this->sql_manager->execute($sql, $bindings);
+    }
+
+    /**
+     * Fermetures des gymnases du club du responsable connecté.
+     * @throws Exception
+     */
+    public function getMyClubBlacklistGymnase(): array
+    {
+        $id_club = (new Club())->getMyClubId();
+        $sql = "SELECT  bg.id,
+                        bg.id_gymnase,
+                        CONCAT(g.nom, ' (', g.ville, ')') AS libelle_gymnase,
+                        DATE_FORMAT(bg.closed_date, '%d/%m/%Y') AS closed_date
+                FROM blacklist_gymnase bg
+                JOIN gymnase g ON bg.id_gymnase = g.id
+                WHERE bg.id_gymnase IN (
+                    SELECT DISTINCT cr.id_gymnase
+                    FROM creneau cr
+                    JOIN equipes e ON e.id_equipe = cr.id_equipe
+                    WHERE e.id_club = ?
+                )
+                ORDER BY bg.closed_date";
+        $bindings = array(array('type' => 'i', 'value' => $id_club));
+        return $this->sql_manager->execute($sql, $bindings);
+    }
+
+    /**
+     * Supprime une fermeture de gymnase. Pour un responsable de club, vérifie
+     * que la fermeture concerne bien un gymnase de son club.
+     * @throws Exception
+     */
+    public function removeBlacklistGymnase($id): void
+    {
+        if (!UserManager::isAdmin()) {
+            if (!UserManager::isClubLeader()) {
+                throw new Exception("Vous n'êtes pas autorisé à effectuer cette action !", 403);
+            }
+            $row = $this->get_by_id($id);
+            $this->assertClubGymnasium($row['id_gymnase']);
+        }
+        $this->delete($id);
+        $this->addActivity("Une fermeture de gymnase a été supprimée");
+    }
+
+    /**
+     * Vérifie que le gymnase fait partie de ceux utilisés par le club du
+     * responsable connecté.
+     * @throws Exception
+     */
+    private function assertClubGymnasium($id_gymnase): void
+    {
+        foreach ($this->getMyClubGymnasiums() as $gym) {
+            if ($gym['id'] == $id_gymnase) {
+                return;
+            }
+        }
+        throw new Exception("Ce gymnase n'est pas utilisé par votre club !", 403);
     }
 
 }

--- a/classes/BlackListTeam.php
+++ b/classes/BlackListTeam.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . "/Generic.php";
+require_once __DIR__ . "/Club.php";
 
 class BlackListTeam extends Generic
 {
@@ -15,12 +16,57 @@ class BlackListTeam extends Generic
                                       $dirtyFields = null,
                                       $id = null)
     {
+        // Un responsable de club ne peut déclarer une indisponibilité que pour
+        // une équipe de son club.
+        if (!UserManager::isAdmin()) {
+            if (!UserManager::isClubLeader()) {
+                throw new Exception("Vous n'êtes pas autorisé à effectuer cette action !", 403);
+            }
+            (new Club())->assertManagesTeam($id_team);
+        }
         $inputs = array();
         $inputs['id_team'] = $id_team;
         $inputs['closed_date'] = $closed_date;
         $inputs['dirtyFields'] = $dirtyFields;
         $inputs['id'] = $id;
         $this->save($inputs);
+    }
+
+    /**
+     * Indisponibilités des équipes du club du responsable connecté.
+     * @throws Exception
+     */
+    public function getMyClubBlacklistTeam(): array
+    {
+        $id_club = (new Club())->getMyClubId();
+        $sql = "SELECT  bt.id,
+                        bt.id_team,
+                        CONCAT(e.nom_equipe, ' (', e.code_competition, ')') AS libelle_equipe,
+                        DATE_FORMAT(bt.closed_date, '%d/%m/%Y') AS closed_date
+                FROM blacklist_team bt
+                JOIN equipes e ON e.id_equipe = bt.id_team
+                WHERE e.id_club = ?
+                ORDER BY bt.closed_date";
+        $bindings = array(array('type' => 'i', 'value' => $id_club));
+        return $this->sql_manager->execute($sql, $bindings);
+    }
+
+    /**
+     * Supprime une indisponibilité d'équipe. Pour un responsable de club,
+     * vérifie que l'équipe appartient bien à son club.
+     * @throws Exception
+     */
+    public function removeBlacklistTeam($id): void
+    {
+        if (!UserManager::isAdmin()) {
+            if (!UserManager::isClubLeader()) {
+                throw new Exception("Vous n'êtes pas autorisé à effectuer cette action !", 403);
+            }
+            $row = $this->get_by_id($id);
+            (new Club())->assertManagesTeam($row['id_team']);
+        }
+        $this->delete($id);
+        $this->addActivity("Une indisponibilité d'équipe a été supprimée");
     }
 
     public function save($inputs)

--- a/classes/Club.php
+++ b/classes/Club.php
@@ -65,12 +65,65 @@ class Club extends Generic
 
     public function getClubName($idClub)
     {
-        $sql = "SELECT 
-        c.nom AS club_name 
-        FROM clubs c 
+        $sql = "SELECT
+        c.nom AS club_name
+        FROM clubs c
         WHERE c.id = $idClub";
         $results = $this->sql_manager->execute($sql);
         return $results[0]['club_name'];
+    }
+
+    /**
+     * Identifiant du club du responsable de club connecté.
+     * Le club est posé en session au login (depuis users_clubs).
+     * @throws Exception
+     */
+    public function getMyClubId(): int
+    {
+        @session_start();
+        if (!UserManager::isClubLeader()) {
+            throw new Exception("Seul un responsable de club peut faire ça !", 403);
+        }
+        if (empty($_SESSION['id_club'])) {
+            throw new Exception("Aucun club n'est rattaché à votre compte !", 403);
+        }
+        return (int)$_SESSION['id_club'];
+    }
+
+    /**
+     * Liste les équipes du club du responsable de club connecté
+     * (sert au sélecteur d'équipe de l'espace responsable).
+     * @throws Exception
+     */
+    public function getMyClubTeams(): array
+    {
+        $id_club = $this->getMyClubId();
+        $sql = "SELECT
+                    e.id_equipe,
+                    e.nom_equipe,
+                    e.code_competition,
+                    comp.libelle AS libelle_competition,
+                    CONCAT(e.nom_equipe, IFNULL(CONCAT(' (', comp.libelle, ')'), '')) AS team_full_name
+                FROM equipes e
+                LEFT JOIN competitions comp ON comp.code_competition = e.code_competition
+                WHERE e.id_club = ?
+                ORDER BY comp.libelle, e.nom_equipe";
+        $bindings = array(array('type' => 'i', 'value' => $id_club));
+        return $this->sql_manager->execute($sql, $bindings);
+    }
+
+    /**
+     * Vérifie que l'équipe appartient bien au club du responsable connecté.
+     * @throws Exception
+     */
+    public function assertManagesTeam($id_equipe): void
+    {
+        foreach ($this->getMyClubTeams() as $team) {
+            if ($team['id_equipe'] == $id_equipe) {
+                return;
+            }
+        }
+        throw new Exception("Cette équipe n'appartient pas à votre club !", 403);
     }
 
 

--- a/classes/Club.php
+++ b/classes/Club.php
@@ -103,7 +103,14 @@ class Club extends Generic
                     e.nom_equipe,
                     e.code_competition,
                     comp.libelle AS libelle_competition,
-                    CONCAT(e.nom_equipe, IFNULL(CONCAT(' (', comp.libelle, ')'), '')) AS team_full_name
+                    CONCAT(e.nom_equipe, IFNULL(CONCAT(' (', comp.libelle, ')'), '')) AS team_full_name,
+                    (SELECT COUNT(DISTINCT cl.code_competition)
+                       FROM classements cl
+                      WHERE cl.id_equipe = e.id_equipe) AS nb_competitions,
+                    (SELECT GROUP_CONCAT(DISTINCT CONCAT(cc.libelle, IFNULL(CONCAT(' ', cl.division), '')) ORDER BY cc.libelle SEPARATOR ', ')
+                       FROM classements cl
+                       JOIN competitions cc ON cc.code_competition = cl.code_competition
+                      WHERE cl.id_equipe = e.id_equipe) AS competitions
                 FROM equipes e
                 LEFT JOIN competitions comp ON comp.code_competition = e.code_competition
                 WHERE e.id_club = ?

--- a/classes/MatchMgr.php
+++ b/classes/MatchMgr.php
@@ -268,23 +268,35 @@ class MatchMgr extends Generic
     public function getMyClubMatches()
     {
         @session_start();
+        // Un responsable de club n'a pas d'équipe propre : on résout le club
+        // directement depuis la session. Sinon, on déduit le club de l'équipe.
+        if (UserManager::isClubLeader() && !empty($_SESSION['id_club'])) {
+            $id_club = (int)$_SESSION['id_club'];
+            return $this->get_matches(
+                "(
+                        m.id_equipe_dom IN (SELECT id_equipe FROM equipes WHERE id_club = $id_club)
+                        OR
+                        m.id_equipe_ext IN (SELECT id_equipe FROM equipes WHERE id_club = $id_club)
+                        )
+                        AND m.match_status NOT IN ('ARCHIVED')");
+        }
         $team_id = $_SESSION['id_equipe'];
         return $this->get_matches(
             "(
-                    m.id_equipe_dom IN (SELECT id_equipe 
-                                        FROM equipes 
+                    m.id_equipe_dom IN (SELECT id_equipe
+                                        FROM equipes
                                         WHERE id_club IN (
-                                            SELECT id_club 
-                                            FROM equipes 
-                                            WHERE id_equipe = $team_id)) 
-                    OR 
-                    m.id_equipe_ext IN (SELECT id_equipe 
-                                        FROM equipes 
-                                        WHERE id_club IN (
-                                            SELECT id_club 
-                                            FROM equipes 
+                                            SELECT id_club
+                                            FROM equipes
                                             WHERE id_equipe = $team_id))
-                    ) 
+                    OR
+                    m.id_equipe_ext IN (SELECT id_equipe
+                                        FROM equipes
+                                        WHERE id_club IN (
+                                            SELECT id_club
+                                            FROM equipes
+                                            WHERE id_equipe = $team_id))
+                    )
                     AND m.match_status NOT IN ('ARCHIVED')");
     }
 

--- a/classes/TimeSlot.php
+++ b/classes/TimeSlot.php
@@ -47,8 +47,8 @@ class TimeSlot extends Generic
         if (UserManager::isAdmin()) {
             throw new Exception("Un administrateur ne peut pas faire ça !");
         }
-        if (!UserManager::isTeamLeader()) {
-            throw new Exception("Seul un responsable d'équipe peut faire ça !");
+        if (!UserManager::isTeamManager()) {
+            throw new Exception("Seul un responsable d'équipe ou de club peut faire ça !");
         }
         $id_team = $_SESSION['id_equipe'];
         return $this->getTimeSlots("c.id_equipe = $id_team");
@@ -135,8 +135,15 @@ class TimeSlot extends Generic
         $dirtyFields = null,
     )
     {
-        if (!UserManager::isAdmin() && !UserManager::isTeamLeader()) {
+        if (!UserManager::isAdmin() && !UserManager::isTeamManager()) {
             throw new Exception("Vous n'êtes pas autorisé à effectuer cette action !");
+        }
+        // Un responsable (équipe ou club) ne peut agir que sur l'équipe sélectionnée
+        // en session : on ignore tout id_equipe transmis pour éviter qu'il cible une
+        // équipe tierce. L'admin peut cibler n'importe quelle équipe.
+        if (!UserManager::isAdmin()) {
+            @session_start();
+            $id_equipe = $_SESSION['id_equipe'];
         }
         if (empty($id_equipe)) {
             @session_start();
@@ -214,8 +221,18 @@ class TimeSlot extends Generic
      */
     public function removeTimeSlot($id)
     {
-        if (!UserManager::isAdmin() && !UserManager::isTeamLeader()) {
+        if (!UserManager::isAdmin() && !UserManager::isTeamManager()) {
             throw new Exception("Vous n'êtes pas autorisé à effectuer cette action !");
+        }
+        // Un responsable ne peut supprimer qu'un créneau d'une équipe qu'il gère.
+        if (!UserManager::isAdmin()) {
+            $timeSlot = $this->getTimeSlot($id);
+            if (UserManager::isClubLeader()) {
+                require_once __DIR__ . '/Club.php';
+                (new Club())->assertManagesTeam($timeSlot['id_equipe']);
+            } elseif ($timeSlot['id_equipe'] != ($_SESSION['id_equipe'] ?? null)) {
+                throw new Exception("Vous n'êtes pas autorisé à supprimer ce créneau !", 403);
+            }
         }
         $sql = "DELETE FROM creneau WHERE id = $id";
         $this->sql_manager->execute($sql);

--- a/classes/TimeSlot.php
+++ b/classes/TimeSlot.php
@@ -47,8 +47,8 @@ class TimeSlot extends Generic
         if (UserManager::isAdmin()) {
             throw new Exception("Un administrateur ne peut pas faire ça !");
         }
-        if (!UserManager::isTeamManager()) {
-            throw new Exception("Seul un responsable d'équipe ou de club peut faire ça !");
+        if (!UserManager::isTeamLeader()) {
+            throw new Exception("Seul un responsable d'équipe peut faire ça !");
         }
         $id_team = $_SESSION['id_equipe'];
         return $this->getTimeSlots("c.id_equipe = $id_team");
@@ -135,15 +135,8 @@ class TimeSlot extends Generic
         $dirtyFields = null,
     )
     {
-        if (!UserManager::isAdmin() && !UserManager::isTeamManager()) {
+        if (!UserManager::isAdmin() && !UserManager::isTeamLeader()) {
             throw new Exception("Vous n'êtes pas autorisé à effectuer cette action !");
-        }
-        // Un responsable (équipe ou club) ne peut agir que sur l'équipe sélectionnée
-        // en session : on ignore tout id_equipe transmis pour éviter qu'il cible une
-        // équipe tierce. L'admin peut cibler n'importe quelle équipe.
-        if (!UserManager::isAdmin()) {
-            @session_start();
-            $id_equipe = $_SESSION['id_equipe'];
         }
         if (empty($id_equipe)) {
             @session_start();
@@ -221,18 +214,8 @@ class TimeSlot extends Generic
      */
     public function removeTimeSlot($id)
     {
-        if (!UserManager::isAdmin() && !UserManager::isTeamManager()) {
+        if (!UserManager::isAdmin() && !UserManager::isTeamLeader()) {
             throw new Exception("Vous n'êtes pas autorisé à effectuer cette action !");
-        }
-        // Un responsable ne peut supprimer qu'un créneau d'une équipe qu'il gère.
-        if (!UserManager::isAdmin()) {
-            $timeSlot = $this->getTimeSlot($id);
-            if (UserManager::isClubLeader()) {
-                require_once __DIR__ . '/Club.php';
-                (new Club())->assertManagesTeam($timeSlot['id_equipe']);
-            } elseif ($timeSlot['id_equipe'] != ($_SESSION['id_equipe'] ?? null)) {
-                throw new Exception("Vous n'êtes pas autorisé à supprimer ce créneau !", 403);
-            }
         }
         $sql = "DELETE FROM creneau WHERE id = $id";
         $this->sql_manager->execute($sql);

--- a/classes/UserManager.php
+++ b/classes/UserManager.php
@@ -732,6 +732,73 @@ class UserManager extends Generic
     }
 
     /**
+     * Liste les équipes du club du responsable de club connecté, avec les
+     * comptes responsables d'équipe qui leur sont rattachés (user_id null si
+     * aucun compte). Sert à l'écran d'attribution des comptes.
+     * @throws Exception
+     */
+    public function getMyClubTeamLeaders(): array
+    {
+        @session_start();
+        if (!self::isClubLeader()) {
+            throw new Exception("Seul un responsable de club peut faire ça !", 403);
+        }
+        require_once __DIR__ . '/Club.php';
+        $id_club = (new Club())->getMyClubId();
+        $sql = "SELECT  e.id_equipe,
+                        e.nom_equipe,
+                        comp.libelle AS libelle_competition,
+                        CONCAT(e.nom_equipe, IFNULL(CONCAT(' (', comp.libelle, ')'), '')) AS team_full_name,
+                        ca.id AS user_id,
+                        ca.login,
+                        ca.email
+                FROM equipes e
+                LEFT JOIN competitions comp ON comp.code_competition = e.code_competition
+                LEFT JOIN users_teams ut ON ut.team_id = e.id_equipe
+                LEFT JOIN comptes_acces ca ON ca.id = ut.user_id
+                WHERE e.id_club = ?
+                ORDER BY comp.libelle, e.nom_equipe, ca.login";
+        $bindings = array(array('type' => 'i', 'value' => $id_club));
+        return $this->sql_manager->execute($sql, $bindings);
+    }
+
+    /**
+     * Crée (si besoin) et rattache un compte RESPONSABLE_EQUIPE à une équipe du
+     * club du responsable connecté.
+     * @throws Exception
+     */
+    public function attachClubTeamLeader($email, $id_equipe): void
+    {
+        @session_start();
+        if (!self::isClubLeader()) {
+            throw new Exception("Seul un responsable de club peut faire ça !", 403);
+        }
+        if (empty($email)) {
+            throw new Exception("L'adresse email est obligatoire !", 400);
+        }
+        require_once __DIR__ . '/Club.php';
+        (new Club())->assertManagesTeam($id_equipe);
+        $this->create_or_update_leader_account($email, $id_equipe);
+    }
+
+    /**
+     * Détache un compte d'une équipe du club du responsable connecté
+     * (supprime le lien users_teams, sans supprimer le compte).
+     * @throws Exception
+     */
+    public function detachClubTeamLeader($user_id, $id_equipe): void
+    {
+        @session_start();
+        if (!self::isClubLeader()) {
+            throw new Exception("Seul un responsable de club peut faire ça !", 403);
+        }
+        require_once __DIR__ . '/Club.php';
+        (new Club())->assertManagesTeam($id_equipe);
+        $this->delete_user_team($user_id, $id_equipe);
+        $this->addActivity("Compte " . $this->getUserLogin($user_id) . " détaché de l'équipe " . $this->team->getTeamName($id_equipe));
+    }
+
+    /**
      * Initialise la session d'un RESPONSABLE_CLUB : résout son club depuis
      * users_clubs et sélectionne par défaut la première équipe du club.
      * @throws Exception

--- a/classes/UserManager.php
+++ b/classes/UserManager.php
@@ -468,16 +468,6 @@ class UserManager extends Generic
         return (isset($_SESSION['profile_name']) && $_SESSION['profile_name'] == "RESPONSABLE_CLUB");
     }
 
-    /**
-     * Responsable habilité à gérer une équipe : responsable d'équipe OU de club.
-     * Un RESPONSABLE_CLUB agit sur l'équipe sélectionnée ($_SESSION['id_equipe']),
-     * laquelle est restreinte aux équipes de son club par switchCurrentUserTeam().
-     */
-    public static function isTeamManager(): bool
-    {
-        return self::isTeamLeader() || self::isClubLeader();
-    }
-
     public static function isAdmin(): bool
     {
         @session_start();
@@ -811,14 +801,9 @@ class UserManager extends Generic
         if (count($results) === 0) {
             return;
         }
+        // Le responsable de club n'a pas d'équipe propre : il gère ses équipes en
+        // « agissant en tant que » leur responsable (cf. switch_to_club_team_leader).
         $_SESSION['id_club'] = (int)$results[0]['club_id'];
-        $teams = $this->sql_manager->execute(
-            "SELECT id_equipe FROM equipes WHERE id_club = ? ORDER BY id_equipe LIMIT 1",
-            array(array('type' => 'i', 'value' => $_SESSION['id_club']))
-        );
-        if (count($teams) > 0) {
-            $_SESSION['id_equipe'] = (int)$teams[0]['id_equipe'];
-        }
     }
 
     public function switchCurrentUserTeam($id_equipe): void
@@ -828,18 +813,6 @@ class UserManager extends Generic
         }
         if (!(isset($_SESSION['login']))) {
             throw new Exception("Utilisateur non connecté !");
-        }
-        // Un responsable de club peut basculer sur n'importe quelle équipe de son club.
-        if (self::isClubLeader()) {
-            require_once __DIR__ . '/Club.php';
-            $club = new Club();
-            foreach ($club->getMyClubTeams() as $club_team) {
-                if ($club_team['id_equipe'] == $id_equipe) {
-                    $_SESSION['id_equipe'] = (int)$id_equipe;
-                    return;
-                }
-            }
-            throw new Exception("Equipe non autorisée !");
         }
         $available_teams = $this->getUserTeams($_SESSION['id_user']);
         foreach ($available_teams as $available_team) {
@@ -970,7 +943,69 @@ class UserManager extends Generic
         $_SESSION['acting_as'] = true;
         
         $this->activity->add("Admin a basculé vers le compte: " . $data['login'], $_SESSION['original_admin_id']);
-        
+
+        return true;
+    }
+
+    /**
+     * Permet à un responsable de club d'agir en tant qu'un compte responsable
+     * d'équipe de SON club (réutilise le mécanisme "agir en tant que").
+     * @param int $target_user_id ID du compte responsable d'équipe cible
+     * @return bool
+     * @throws Exception
+     */
+    public function switch_to_club_team_leader(int $target_user_id): bool
+    {
+        @session_start();
+
+        if (!self::isClubLeader()) {
+            throw new Exception("Seul un responsable de club peut faire ça !", 403);
+        }
+        if (self::is_acting_as()) {
+            throw new Exception("Vous agissez déjà en tant qu'un autre compte. Revenez d'abord à votre compte club.");
+        }
+
+        require_once __DIR__ . '/Club.php';
+        $club = new Club();
+        $clubTeamIds = array_map('intval', array_column($club->getMyClubTeams(), 'id_equipe'));
+        $targetTeamIds = array_map('intval', $this->getUserTeamIds($target_user_id));
+        $sharedTeamIds = array_values(array_intersect($targetTeamIds, $clubTeamIds));
+        if (count($sharedTeamIds) === 0) {
+            throw new Exception("Ce compte ne gère aucune équipe de votre club !", 403);
+        }
+
+        // sauvegarde de la session du responsable de club
+        $_SESSION['original_admin_id'] = $_SESSION['id_user'];
+        $_SESSION['original_admin_login'] = $_SESSION['login'];
+        $_SESSION['original_admin_profile'] = $_SESSION['profile_name'];
+        $_SESSION['original_admin_equipe'] = $_SESSION['id_equipe'] ?? null;
+        $_SESSION['original_admin_club'] = $_SESSION['id_club'] ?? null;
+
+        $sql = "SELECT  ca.login,
+                        ca.id AS id_user,
+                        p.name AS profile_name
+                FROM comptes_acces ca
+                LEFT JOIN users_profiles up ON up.user_id = ca.id
+                LEFT JOIN profiles p ON p.id = up.profile_id
+                WHERE ca.id = ?
+                LIMIT 1";
+        $bindings = array(array('type' => 'i', 'value' => $target_user_id));
+        $results = $this->sql_manager->execute($sql, $bindings);
+        if (count($results) === 0) {
+            throw new Exception("Compte cible introuvable !");
+        }
+        $data = $results[0];
+        // on cible une équipe du club (la première partagée), pour que toute l'UI
+        // responsable opère sur une équipe du club même si le compte en gère d'autres
+        $_SESSION['id_equipe'] = $sharedTeamIds[0];
+        $_SESSION['login'] = $data['login'];
+        $_SESSION['id_user'] = (int)$data['id_user'];
+        $_SESSION['profile_name'] = $data['profile_name'];
+        unset($_SESSION['id_club']); // pendant l'act-as, on agit en responsable d'équipe
+        $_SESSION['acting_as'] = true;
+
+        $this->activity->add("Responsable de club a basculé vers le compte: " . $data['login'], $_SESSION['original_admin_id']);
+
         return true;
     }
 
@@ -993,15 +1028,23 @@ class UserManager extends Generic
         $_SESSION['login'] = $_SESSION['original_admin_login'];
         $_SESSION['profile_name'] = $_SESSION['original_admin_profile'];
         $_SESSION['id_equipe'] = $_SESSION['original_admin_equipe'];
-        
+        // restaure le club d'origine (cas d'un responsable de club ayant agi en
+        // tant qu'un de ses responsables d'équipe)
+        if (array_key_exists('original_admin_club', $_SESSION)) {
+            if ($_SESSION['original_admin_club'] !== null) {
+                $_SESSION['id_club'] = (int)$_SESSION['original_admin_club'];
+            }
+            unset($_SESSION['original_admin_club']);
+        }
+
         unset($_SESSION['acting_as']);
         unset($_SESSION['original_admin_id']);
         unset($_SESSION['original_admin_login']);
         unset($_SESSION['original_admin_profile']);
         unset($_SESSION['original_admin_equipe']);
-        
-        $this->activity->add("Admin est revenu de: " . $target_login);
-        
+
+        $this->activity->add("Compte d'origine restauré depuis: " . $target_login);
+
         return true;
     }
 

--- a/classes/UserManager.php
+++ b/classes/UserManager.php
@@ -739,6 +739,13 @@ class UserManager extends Generic
                         e.nom_equipe,
                         comp.libelle AS libelle_competition,
                         CONCAT(e.nom_equipe, IFNULL(CONCAT(' (', comp.libelle, ')'), '')) AS team_full_name,
+                        (SELECT COUNT(DISTINCT cl.code_competition)
+                           FROM classements cl
+                          WHERE cl.id_equipe = e.id_equipe) AS nb_competitions,
+                        (SELECT GROUP_CONCAT(DISTINCT CONCAT(cc.libelle, IFNULL(CONCAT(' ', cl.division), '')) ORDER BY cc.libelle SEPARATOR ', ')
+                           FROM classements cl
+                           JOIN competitions cc ON cc.code_competition = cl.code_competition
+                          WHERE cl.id_equipe = e.id_equipe) AS competitions,
                         ca.id AS user_id,
                         ca.login,
                         ca.email

--- a/classes/UserManager.php
+++ b/classes/UserManager.php
@@ -462,6 +462,22 @@ class UserManager extends Generic
         return (isset($_SESSION['profile_name']) && $_SESSION['profile_name'] == "RESPONSABLE_EQUIPE");
     }
 
+    public static function isClubLeader(): bool
+    {
+        @session_start();
+        return (isset($_SESSION['profile_name']) && $_SESSION['profile_name'] == "RESPONSABLE_CLUB");
+    }
+
+    /**
+     * Responsable habilité à gérer une équipe : responsable d'équipe OU de club.
+     * Un RESPONSABLE_CLUB agit sur l'équipe sélectionnée ($_SESSION['id_equipe']),
+     * laquelle est restreinte aux équipes de son club par switchCurrentUserTeam().
+     */
+    public static function isTeamManager(): bool
+    {
+        return self::isTeamLeader() || self::isClubLeader();
+    }
+
     public static function isAdmin(): bool
     {
         @session_start();
@@ -533,6 +549,11 @@ class UserManager extends Generic
         $_SESSION['login'] = $data['login'];
         $_SESSION['id_user'] = (int)$data['id_user'];
         $_SESSION['profile_name'] = $data['profile_name'];
+        // Responsable de club : résoudre le club (users_clubs) et sélectionner par
+        // défaut une équipe du club (le profil n'a pas de ligne users_teams).
+        if ($_SESSION['profile_name'] === 'RESPONSABLE_CLUB') {
+            $this->initClubLeaderSession((int)$data['id_user']);
+        }
         if (!empty($redirect)) {
             header('Location: ' . urldecode($redirect));
             exit(0);
@@ -710,6 +731,29 @@ class UserManager extends Generic
         return $this->sql_manager->execute($sql, $bindings);
     }
 
+    /**
+     * Initialise la session d'un RESPONSABLE_CLUB : résout son club depuis
+     * users_clubs et sélectionne par défaut la première équipe du club.
+     * @throws Exception
+     */
+    private function initClubLeaderSession(int $id_user): void
+    {
+        $sql = "SELECT club_id FROM users_clubs WHERE user_id = ? LIMIT 1";
+        $bindings = array(array('type' => 'i', 'value' => $id_user));
+        $results = $this->sql_manager->execute($sql, $bindings);
+        if (count($results) === 0) {
+            return;
+        }
+        $_SESSION['id_club'] = (int)$results[0]['club_id'];
+        $teams = $this->sql_manager->execute(
+            "SELECT id_equipe FROM equipes WHERE id_club = ? ORDER BY id_equipe LIMIT 1",
+            array(array('type' => 'i', 'value' => $_SESSION['id_club']))
+        );
+        if (count($teams) > 0) {
+            $_SESSION['id_equipe'] = (int)$teams[0]['id_equipe'];
+        }
+    }
+
     public function switchCurrentUserTeam($id_equipe): void
     {
         if (!(isset($_SESSION['login']))) {
@@ -717,6 +761,18 @@ class UserManager extends Generic
         }
         if (!(isset($_SESSION['login']))) {
             throw new Exception("Utilisateur non connecté !");
+        }
+        // Un responsable de club peut basculer sur n'importe quelle équipe de son club.
+        if (self::isClubLeader()) {
+            require_once __DIR__ . '/Club.php';
+            $club = new Club();
+            foreach ($club->getMyClubTeams() as $club_team) {
+                if ($club_team['id_equipe'] == $id_equipe) {
+                    $_SESSION['id_equipe'] = (int)$id_equipe;
+                    return;
+                }
+            }
+            throw new Exception("Equipe non autorisée !");
         }
         $available_teams = $this->getUserTeams($_SESSION['id_user']);
         foreach ($available_teams as $available_team) {

--- a/pages/components/layout/TeamLeaderLayout.js
+++ b/pages/components/layout/TeamLeaderLayout.js
@@ -45,6 +45,10 @@ const routes = [
         component: () => import('../panel/ClubGymnasiumClosures.js')
     },
     {
+        path: '/club_team_unavailability',
+        component: () => import('../panel/ClubTeamUnavailability.js')
+    },
+    {
         path: '/players',
         component: () => import('../panel/Players.js'),
         props: () => ({fetchUrl: "/rest/action.php/player/getMyPlayers"})

--- a/pages/components/layout/TeamLeaderLayout.js
+++ b/pages/components/layout/TeamLeaderLayout.js
@@ -41,6 +41,10 @@ const routes = [
         props: () => ({fetchUrl: "/rest/action.php/timeslot/get_my_timeslots"})
     },
     {
+        path: '/club_gymnasium_closures',
+        component: () => import('../panel/ClubGymnasiumClosures.js')
+    },
+    {
         path: '/players',
         component: () => import('../panel/Players.js'),
         props: () => ({fetchUrl: "/rest/action.php/player/getMyPlayers"})

--- a/pages/components/layout/TeamLeaderLayout.js
+++ b/pages/components/layout/TeamLeaderLayout.js
@@ -49,6 +49,10 @@ const routes = [
         component: () => import('../panel/ClubTeamUnavailability.js')
     },
     {
+        path: '/club_team_leaders',
+        component: () => import('../panel/ClubTeamLeaders.js')
+    },
+    {
         path: '/players',
         component: () => import('../panel/Players.js'),
         props: () => ({fetchUrl: "/rest/action.php/player/getMyPlayers"})

--- a/pages/components/navbar/TeamLeader.js
+++ b/pages/components/navbar/TeamLeader.js
@@ -47,6 +47,9 @@ export default {
                 <li>
                   <router-link to="/club_gymnasium_closures"><span><i class="mr-2 fas fa-lock"></i>fermetures gymnases</span></router-link>
                 </li>
+                <li>
+                  <router-link to="/club_team_unavailability"><span><i class="mr-2 fas fa-ban"></i>indispos équipes</span></router-link>
+                </li>
               </ul>
             </div>
             <div class="dropdown">

--- a/pages/components/navbar/TeamLeader.js
+++ b/pages/components/navbar/TeamLeader.js
@@ -50,6 +50,9 @@ export default {
                 <li>
                   <router-link to="/club_team_unavailability"><span><i class="mr-2 fas fa-ban"></i>indispos équipes</span></router-link>
                 </li>
+                <li>
+                  <router-link to="/club_team_leaders"><span><i class="mr-2 fas fa-user-gear"></i>comptes responsables</span></router-link>
+                </li>
               </ul>
             </div>
             <div class="dropdown">

--- a/pages/components/navbar/TeamLeader.js
+++ b/pages/components/navbar/TeamLeader.js
@@ -37,6 +37,18 @@ export default {
                 </li>
               </ul>
             </div>
+            <div v-if="isClubLeader" class="dropdown">
+              <div tabindex="0" role="button" class="btn btn-ghost">
+                <span><i class="mr-2 fas fa-people-group"></i>gestion club<i class="ml-1 fas fa-chevron-down"/></span>
+              </div>
+              <ul
+                  tabindex="0"
+                  class="dropdown-content menu bg-base-100 rounded-box z-50 mt-3 w-60 p-2 shadow">
+                <li>
+                  <router-link to="/club_gymnasium_closures"><span><i class="mr-2 fas fa-lock"></i>fermetures gymnases</span></router-link>
+                </li>
+              </ul>
+            </div>
             <div class="dropdown">
               <div tabindex="0" role="button" class="btn btn-ghost">
                 <span>infos<i class="ml-1 fas fa-chevron-down"/></span>

--- a/pages/components/navbar/TeamLeader.js
+++ b/pages/components/navbar/TeamLeader.js
@@ -28,9 +28,13 @@ export default {
                   Aucun compte responsable rattaché. Créez-en un dans « gestion club ».
                 </li>
                 <li v-for="account in actAsAccounts" :key="account.user_id + '-' + account.id_equipe">
-                  <a @click="actAs(account.user_id)">
-                    <i class="fas fa-people-group mr-2"></i>{{ account.team_full_name }}
-                    <span class="opacity-60">({{ account.login }})</span>
+                  <a @click="actAs(account.user_id)" class="flex flex-col items-start gap-1 py-2">
+                    <span><i class="fas fa-people-group mr-2"></i>{{ account.team_full_name }}
+                      <span class="opacity-60">({{ account.login }})</span></span>
+                    <span v-if="parseInt(account.nb_competitions) > 0" class="badge badge-success badge-sm gap-1">
+                      <i class="fas fa-trophy"></i>{{ account.competitions }}
+                    </span>
+                    <span v-else class="badge badge-ghost badge-sm">non engagée cette saison</span>
                   </a>
                 </li>
               </ul>

--- a/pages/components/navbar/TeamLeader.js
+++ b/pages/components/navbar/TeamLeader.js
@@ -12,7 +12,7 @@ export default {
             </a>
             <div class="dropdown">
               <div tabindex="0" role="button" class="btn btn-ghost">
-                <span><i class="mr-2 fas fa-user"></i>mon équipe: {{ currentTeam.nom_equipe }}<i class="ml-1 fas fa-chevron-down"/></span>
+                <span><i class="mr-2 fas" :class="isClubLeader ? 'fa-people-group' : 'fa-user'"></i>{{ isClubLeader ? 'club' : 'mon équipe' }}: {{ currentTeam?.nom_equipe }}<i class="ml-1 fas fa-chevron-down"/></span>
               </div>
               <ul
                   tabindex="0"
@@ -89,6 +89,7 @@ export default {
             currentTeam: null,
             teams: null,
             unreadCount: 0,
+            isClubLeader: false,
         };
     },
     methods: {
@@ -111,7 +112,13 @@ export default {
                         this.user = null;
                     } else {
                         this.user = response.data;
-                        axios.get(`/rest/action.php/usermanager/getUserTeams?user_id=${this.user.id_user}`).then((response) => {
+                        this.isClubLeader = this.user.profile_name === 'RESPONSABLE_CLUB';
+                        // Le responsable de club choisit parmi toutes les équipes de son club ;
+                        // le responsable d'équipe parmi les équipes qui lui sont rattachées.
+                        const teamsUrl = this.isClubLeader
+                            ? `/rest/action.php/club/getMyClubTeams`
+                            : `/rest/action.php/usermanager/getUserTeams?user_id=${this.user.id_user}`;
+                        axios.get(teamsUrl).then((response) => {
                             this.teams = response.data;
                             this.currentTeam = this.teams.find((item) => item.id_equipe == this.user.id_equipe)
                         })

--- a/pages/components/navbar/TeamLeader.js
+++ b/pages/components/navbar/TeamLeader.js
@@ -6,13 +6,40 @@ export default {
             <img alt="Ufolep" src="../images/logo-2026.png" style="max-height:150px;">
           </a>
         </div>
+        <div v-if="isActingAs" class="alert alert-warning flex flex-wrap justify-center items-center gap-2 my-2">
+          <span><i class="fas fa-user-secret mr-2"></i>Vous gérez l'équipe en tant que <strong>{{ user?.login }}</strong></span>
+          <button class="btn btn-sm btn-neutral" @click="switchBackToClub">
+            <i class="fas fa-arrow-left mr-1"></i>revenir au compte club
+          </button>
+        </div>
         <div class="navbar bg-base-100 shadow-sm flex flex-wrap justify-center gap-2">
             <a href="/" class="btn btn-ghost">
               <span><i class="mr-2 fas fa-arrow-left"></i>retour</span>
             </a>
-            <div class="dropdown">
+
+            <!-- Responsable de club (hors act-as) : choisir un compte responsable à incarner -->
+            <div v-if="isClubLeader" class="dropdown">
+              <div tabindex="0" role="button" class="btn btn-primary">
+                <span><i class="mr-2 fas fa-user-secret"></i>gérer une équipe<i class="ml-1 fas fa-chevron-down"/></span>
+              </div>
+              <ul tabindex="0"
+                  class="dropdown-content menu bg-base-100 rounded-box z-50 mt-3 w-72 p-2 shadow max-h-96 overflow-y-auto">
+                <li v-if="actAsAccounts.length === 0" class="opacity-60 p-2 text-sm">
+                  Aucun compte responsable rattaché. Créez-en un dans « gestion club ».
+                </li>
+                <li v-for="account in actAsAccounts" :key="account.user_id + '-' + account.id_equipe">
+                  <a @click="actAs(account.user_id)">
+                    <i class="fas fa-people-group mr-2"></i>{{ account.team_full_name }}
+                    <span class="opacity-60">({{ account.login }})</span>
+                  </a>
+                </li>
+              </ul>
+            </div>
+
+            <!-- Responsable d'équipe (ou club en act-as) : sélecteur de son équipe -->
+            <div v-if="!isClubLeader" class="dropdown">
               <div tabindex="0" role="button" class="btn btn-ghost">
-                <span><i class="mr-2 fas" :class="isClubLeader ? 'fa-people-group' : 'fa-user'"></i>{{ isClubLeader ? 'club' : 'mon équipe' }}: {{ currentTeam?.nom_equipe }}<i class="ml-1 fas fa-chevron-down"/></span>
+                <span><i class="mr-2 fas fa-user"></i>mon équipe: {{ currentTeam?.nom_equipe }}<i class="ml-1 fas fa-chevron-down"/></span>
               </div>
               <ul
                   tabindex="0"
@@ -22,21 +49,65 @@ export default {
                 </li>
               </ul>
             </div>
-            <div class="dropdown">
-              <div tabindex="0" role="button" class="btn btn-ghost">
-                <span>gestion<i class="ml-1 fas fa-chevron-down"/></span>
+
+            <!-- Menus per-équipe : cachés pour le responsable de club hors act-as -->
+            <template v-if="!isClubLeader">
+              <div class="dropdown">
+                <div tabindex="0" role="button" class="btn btn-ghost">
+                  <span>gestion<i class="ml-1 fas fa-chevron-down"/></span>
+                </div>
+                <ul
+                    tabindex="0"
+                    class="dropdown-content menu bg-base-100 rounded-box z-50 mt-3 w-52 p-2 shadow">
+                  <li>
+                    <router-link to="/players"><span><i class="mr-2 fas fa-user"></i>effectif</span></router-link>
+                  </li>
+                  <li>
+                    <router-link to="/timeslots"><span><i class="mr-2 fas fa-clock"></i>créneaux</span></router-link>
+                  </li>
+                </ul>
               </div>
-              <ul
-                  tabindex="0"
-                  class="dropdown-content menu bg-base-100 rounded-box z-50 mt-3 w-52 p-2 shadow">
-                <li>
-                  <router-link to="/players"><span><i class="mr-2 fas fa-user"></i>effectif</span></router-link>
-                </li>
-                <li>
-                  <router-link to="/timeslots"><span><i class="mr-2 fas fa-clock"></i>créneaux</span></router-link>
-                </li>
-              </ul>
-            </div>
+              <div class="dropdown">
+                <div tabindex="0" role="button" class="btn btn-ghost">
+                  <span>infos<i class="ml-1 fas fa-chevron-down"/></span>
+                </div>
+                <ul
+                    tabindex="0"
+                    class="dropdown-content menu bg-base-100 rounded-box z-50 mt-3 w-52 p-2 shadow">
+                  <li><a href="/rest/action.php/team/download_calendar"><span><i class="mr-2 fas fa-download"></i>calendrier</span></a>
+                  </li>
+                  <li>
+                    <router-link to="/team"><span><i class="mr-2 fas fa-edit"></i>coordonnées</span></router-link>
+                  </li>
+                  <li>
+                    <router-link to="/history"><span><i class="mr-2 fas fa-calendar"></i>historique</span></router-link>
+                  </li>
+                </ul>
+              </div>
+              <div class="dropdown">
+                <div tabindex="0" role="button" class="btn btn-ghost">
+                  <span>matchs<i class="ml-1 fas fa-chevron-down"/></span>
+                </div>
+                <ul
+                    tabindex="0"
+                    class="dropdown-content menu bg-base-100 rounded-box z-50 mt-3 w-52 p-2 shadow">
+                  <li>
+                    <router-link to="/team_matchs"><span><i class="fas fa-volleyball mr-2"></i>
+                      equipe</span></router-link>
+                  </li>
+                  <li>
+                    <router-link to="/club_matchs"><span><i class="fas fa-volleyball mr-2"></i>club</span>
+                    </router-link>
+                  </li>
+                </ul>
+              </div>
+              <router-link to="/messages" class="btn btn-ghost relative">
+                <span><i class="mr-2 fas fa-envelope"></i>messages</span>
+                <span v-if="unreadCount > 0" class="badge badge-error badge-xs absolute -top-1 -right-1">{{ unreadCount }}</span>
+              </router-link>
+            </template>
+
+            <!-- Menu club-wide : visible seulement pour le responsable de club -->
             <div v-if="isClubLeader" class="dropdown">
               <div tabindex="0" role="button" class="btn btn-ghost">
                 <span><i class="mr-2 fas fa-people-group"></i>gestion club<i class="ml-1 fas fa-chevron-down"/></span>
@@ -55,44 +126,7 @@ export default {
                 </li>
               </ul>
             </div>
-            <div class="dropdown">
-              <div tabindex="0" role="button" class="btn btn-ghost">
-                <span>infos<i class="ml-1 fas fa-chevron-down"/></span>
-              </div>
-              <ul
-                  tabindex="0"
-                  class="dropdown-content menu bg-base-100 rounded-box z-50 mt-3 w-52 p-2 shadow">
-                <li><a href="/rest/action.php/team/download_calendar"><span><i class="mr-2 fas fa-download"></i>calendrier</span></a>
-                </li>
-                <li>
-                  <router-link to="/team"><span><i class="mr-2 fas fa-edit"></i>coordonnées</span></router-link>
-                </li>
-                <li>
-                  <router-link to="/history"><span><i class="mr-2 fas fa-calendar"></i>historique</span></router-link>
-                </li>
-              </ul>
-            </div>
-            <div class="dropdown">
-              <div tabindex="0" role="button" class="btn btn-ghost">
-                <span>matchs<i class="ml-1 fas fa-chevron-down"/></span>
-              </div>
-              <ul
-                  tabindex="0"
-                  class="dropdown-content menu bg-base-100 rounded-box z-50 mt-3 w-52 p-2 shadow">
-                <li>
-                  <router-link to="/team_matchs"><span><i class="fas fa-volleyball mr-2"></i>
-                    equipe</span></router-link>
-                </li>
-                <li>
-                  <router-link to="/club_matchs"><span><i class="fas fa-volleyball mr-2"></i>club</span>
-                  </router-link>
-                </li>
-              </ul>
-            </div>
-            <router-link to="/messages" class="btn btn-ghost relative">
-              <span><i class="mr-2 fas fa-envelope"></i>messages</span>
-              <span v-if="unreadCount > 0" class="badge badge-error badge-xs absolute -top-1 -right-1">{{ unreadCount }}</span>
-            </router-link>
+
             <router-link to="/preferences" class="btn btn-ghost">
               <span><i class="mr-2 fas fa-gear"></i>préférences</span>
             </router-link>
@@ -108,6 +142,8 @@ export default {
             teams: null,
             unreadCount: 0,
             isClubLeader: false,
+            isActingAs: false,
+            actAsAccounts: [],
         };
     },
     methods: {
@@ -128,18 +164,25 @@ export default {
                 .then((response) => {
                     if (response.data.error) {
                         this.user = null;
+                        return;
+                    }
+                    this.user = response.data;
+                    this.isActingAs = this.user.is_acting_as === true;
+                    this.isClubLeader = this.user.profile_name === 'RESPONSABLE_CLUB';
+                    if (this.isClubLeader) {
+                        // Liste des comptes responsables d'équipe du club, à incarner.
+                        axios.get('/rest/action.php/usermanager/getMyClubTeamLeaders')
+                            .then((r) => {
+                                this.actAsAccounts = r.data.filter((row) => row.user_id);
+                            })
+                            .catch(() => {});
                     } else {
-                        this.user = response.data;
-                        this.isClubLeader = this.user.profile_name === 'RESPONSABLE_CLUB';
-                        // Le responsable de club choisit parmi toutes les équipes de son club ;
-                        // le responsable d'équipe parmi les équipes qui lui sont rattachées.
-                        const teamsUrl = this.isClubLeader
-                            ? `/rest/action.php/club/getMyClubTeams`
-                            : `/rest/action.php/usermanager/getUserTeams?user_id=${this.user.id_user}`;
-                        axios.get(teamsUrl).then((response) => {
-                            this.teams = response.data;
-                            this.currentTeam = this.teams.find((item) => item.id_equipe == this.user.id_equipe)
-                        })
+                        // Responsable d'équipe (ou club en act-as) : ses équipes.
+                        axios.get(`/rest/action.php/usermanager/getUserTeams?user_id=${this.user.id_user}`)
+                            .then((r) => {
+                                this.teams = r.data;
+                                this.currentTeam = this.teams.find((item) => item.id_equipe == this.user.id_equipe);
+                            });
                     }
                 })
                 .catch((error) => {
@@ -157,6 +200,38 @@ export default {
                 .catch((error) => {
                     console.error('Erreur lors du changement d\'équipe:', error);
                     alert('Erreur lors du changement d\'équipe');
+                });
+        },
+        actAs(user_id) {
+            const formData = new FormData();
+            formData.append('target_user_id', user_id);
+            axios
+                .post(`/rest/action.php/usermanager/switch_to_club_team_leader`, formData)
+                .then((response) => {
+                    if (response.data.success) {
+                        window.location.href = '/pages/my_page.html';
+                    } else {
+                        alert('Erreur: ' + response.data.message);
+                    }
+                })
+                .catch((error) => {
+                    console.error('Erreur lors du changement de compte:', error);
+                    alert(error.response?.data?.message || 'Erreur lors du changement de compte');
+                });
+        },
+        switchBackToClub() {
+            axios
+                .post(`/rest/action.php/usermanager/switch_back_to_admin`)
+                .then((response) => {
+                    if (response.data.success) {
+                        window.location.href = '/pages/my_page.html';
+                    } else {
+                        alert('Erreur: ' + response.data.message);
+                    }
+                })
+                .catch((error) => {
+                    console.error('Erreur lors du retour au compte club:', error);
+                    alert('Erreur de communication avec le serveur');
                 });
         },
     },

--- a/pages/components/panel/ClubGymnasiumClosures.js
+++ b/pages/components/panel/ClubGymnasiumClosures.js
@@ -1,0 +1,128 @@
+import {onError, onSuccess} from "../../../toaster.js";
+
+/**
+ * Issue #101 — Fermetures des gymnases du club (responsable de club).
+ *
+ * Panneau club-scoped (indépendant de l'équipe sélectionnée) : le responsable
+ * de club déclare les dates de fermeture des gymnases utilisés par ses équipes.
+ * Les endpoints REST (blacklistcourt/*) restreignent côté serveur aux gymnases
+ * du club.
+ */
+export default {
+    template: `
+      <div>
+        <p class="text-xl">Fermetures des gymnases du club</p>
+        <p class="text-sm opacity-70 mb-4">
+          Déclarez les dates où un gymnase utilisé par vos équipes est fermé.
+          Ces fermetures sont prises en compte lors de la génération du calendrier.
+        </p>
+        <div class="flex flex-wrap gap-2">
+          <div v-if="closures.length > 0" class="w-full">
+            <div class="bg-base-200 border border-2 border-base-300 p-4 flex flex-wrap gap-2">
+              <div v-for="closure in closures" :key="closure.id" class="card shadow-xl">
+                <div class="card-body">
+                  <h2 class="card-title"><i class="fas fa-lock mr-2"></i>{{ closure.closed_date }}</h2>
+                  <p>{{ closure.libelle_gymnase }}</p>
+                </div>
+                <div class="card-actions justify-end mr-2 mb-2">
+                  <button class="btn btn-error" @click="onRemoveClick(closure)">
+                    <i class="fas fa-trash mr-2"></i>supprimer
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div v-else class="alert alert-info w-full">
+            <span>Aucune fermeture déclarée pour les gymnases de votre club.</span>
+          </div>
+          <div class="w-full">
+            <form class="flex flex-col gap-4 p-4 max-w-md mx-auto border rounded-lg shadow-lg"
+                  @submit.prevent="handleSubmit">
+              <label class="font-bold" for="gymnase">Gymnase</label>
+              <select id="gymnase" name="id_gymnase" v-model="newClosure.id_gymnase" required>
+                <option value="">Sélectionner un gymnase</option>
+                <option v-for="gymnasium in clubGymnasiums" :key="gymnasium.id" :value="gymnasium.id">
+                  {{ gymnasium.full_name }}
+                </option>
+              </select>
+
+              <label class="font-bold" for="closed_date">Date de fermeture</label>
+              <input type="date" id="closed_date" name="closed_date" v-model="newClosure.closed_date" required>
+
+              <button type="submit" class="btn btn-primary">Ajouter une fermeture</button>
+            </form>
+          </div>
+        </div>
+      </div>
+    `,
+    data() {
+        return {
+            clubGymnasiums: [],
+            closures: [],
+            newClosure: {id_gymnase: '', closed_date: ''},
+            isLoading: false,
+        };
+    },
+    methods: {
+        fetchClubGymnasiums() {
+            axios
+                .get("/rest/action.php/blacklistcourt/getMyClubGymnasiums")
+                .then((response) => {
+                    this.clubGymnasiums = response.data;
+                })
+                .catch((error) => {
+                    console.error("Erreur lors du chargement des gymnases :", error);
+                });
+        },
+        fetchClosures() {
+            axios
+                .get("/rest/action.php/blacklistcourt/getMyClubBlacklistGymnase")
+                .then((response) => {
+                    this.closures = response.data;
+                })
+                .catch((error) => {
+                    console.error("Erreur lors du chargement des fermetures :", error);
+                });
+        },
+        // Convertit yyyy-mm-dd (input date) vers dd/mm/yyyy (attendu par le backend)
+        toFrenchDate(isoDate) {
+            if (!isoDate) {
+                return '';
+            }
+            const [y, m, d] = isoDate.split('-');
+            return `${d}/${m}/${y}`;
+        },
+        handleSubmit() {
+            const formData = new FormData();
+            formData.append("id_gymnase", this.newClosure.id_gymnase);
+            formData.append("closed_date", this.toFrenchDate(this.newClosure.closed_date));
+            axios
+                .post(`/rest/action.php/blacklistcourt/saveBlacklistGymnase`, formData)
+                .then((response) => {
+                    onSuccess(this, response);
+                    this.fetchClosures();
+                    this.newClosure = {id_gymnase: '', closed_date: ''};
+                })
+                .catch((error) => {
+                    onError(this, error);
+                });
+        },
+        onRemoveClick(closure) {
+            const formData = new FormData();
+            formData.append("id", closure.id);
+            axios
+                .post(`/rest/action.php/blacklistcourt/removeBlacklistGymnase`, formData)
+                .then((response) => {
+                    onSuccess(this, response);
+                    this.fetchClosures();
+                })
+                .catch((error) => {
+                    onError(this, error);
+                });
+        },
+    },
+    created() {
+        this.fetchClubGymnasiums();
+        this.fetchClosures();
+    },
+};

--- a/pages/components/panel/ClubTeamLeaders.js
+++ b/pages/components/panel/ClubTeamLeaders.js
@@ -21,6 +21,12 @@ export default {
             <div v-for="team in teams" :key="team.id_equipe" class="card shadow-xl w-full md:w-96">
               <div class="card-body">
                 <h2 class="card-title"><i class="fas fa-people-group mr-2"></i>{{ team.team_full_name }}</h2>
+                <div>
+                  <span v-if="parseInt(team.nb_competitions) > 0" class="badge badge-success gap-1">
+                    <i class="fas fa-trophy"></i>{{ team.competitions }}
+                  </span>
+                  <span v-else class="badge badge-ghost">non engagée cette saison</span>
+                </div>
                 <div v-if="team.leaders.length > 0">
                   <div v-for="leader in team.leaders" :key="leader.user_id"
                        class="flex items-center justify-between gap-2 border-b py-1">
@@ -82,6 +88,8 @@ export default {
                     map.set(row.id_equipe, {
                         id_equipe: row.id_equipe,
                         team_full_name: row.team_full_name,
+                        nb_competitions: row.nb_competitions,
+                        competitions: row.competitions,
                         leaders: [],
                     });
                 }

--- a/pages/components/panel/ClubTeamLeaders.js
+++ b/pages/components/panel/ClubTeamLeaders.js
@@ -1,0 +1,131 @@
+import {onError, onSuccess} from "../../../toaster.js";
+
+/**
+ * Issue #101 — Attribution des comptes responsables d'équipe (responsable de club).
+ *
+ * Panneau club-scoped : pour chaque équipe du club, liste les comptes
+ * RESPONSABLE_EQUIPE rattachés et permet d'en créer/rattacher un (par email)
+ * ou de le détacher. Les endpoints REST (usermanager/*) restreignent côté
+ * serveur aux équipes du club.
+ */
+export default {
+    template: `
+      <div>
+        <p class="text-xl">Comptes responsables d'équipe</p>
+        <p class="text-sm opacity-70 mb-4">
+          Rattachez un compte responsable à chaque équipe de votre club. Si le compte
+          n'existe pas encore, il est créé et ses identifiants sont envoyés par email.
+        </p>
+        <div class="flex flex-wrap gap-4">
+          <div class="w-full bg-base-200 border border-2 border-base-300 p-4 flex flex-wrap gap-4">
+            <div v-for="team in teams" :key="team.id_equipe" class="card shadow-xl w-full md:w-96">
+              <div class="card-body">
+                <h2 class="card-title"><i class="fas fa-people-group mr-2"></i>{{ team.team_full_name }}</h2>
+                <div v-if="team.leaders.length > 0">
+                  <div v-for="leader in team.leaders" :key="leader.user_id"
+                       class="flex items-center justify-between gap-2 border-b py-1">
+                    <span><i class="fas fa-user mr-2"></i>{{ leader.login }}</span>
+                    <button class="btn btn-xs btn-error" @click="onDetachClick(team, leader)">
+                      <i class="fas fa-link-slash mr-1"></i>détacher
+                    </button>
+                  </div>
+                </div>
+                <p v-else class="text-sm opacity-60"><i class="fas fa-triangle-exclamation mr-2"></i>aucun compte rattaché</p>
+              </div>
+            </div>
+          </div>
+          <div class="w-full">
+            <form class="flex flex-col gap-4 p-4 max-w-md mx-auto border rounded-lg shadow-lg"
+                  @submit.prevent="handleSubmit">
+              <p class="font-bold text-lg">Rattacher un compte</p>
+              <label class="font-bold" for="equipe">Équipe</label>
+              <select id="equipe" name="id_equipe" v-model="newLink.id_equipe" required>
+                <option value="">Sélectionner une équipe</option>
+                <option v-for="team in teams" :key="team.id_equipe" :value="team.id_equipe">
+                  {{ team.team_full_name }}
+                </option>
+              </select>
+
+              <label class="font-bold" for="email">Email du responsable</label>
+              <input type="email" id="email" name="email" v-model="newLink.email"
+                     placeholder="responsable@exemple.fr" required>
+
+              <button type="submit" class="btn btn-primary">Créer / rattacher</button>
+            </form>
+          </div>
+        </div>
+      </div>
+    `,
+    data() {
+        return {
+            teams: [],
+            newLink: {id_equipe: '', email: ''},
+            isLoading: false,
+        };
+    },
+    methods: {
+        fetchTeamLeaders() {
+            axios
+                .get("/rest/action.php/usermanager/getMyClubTeamLeaders")
+                .then((response) => {
+                    this.teams = this.groupByTeam(response.data);
+                })
+                .catch((error) => {
+                    console.error("Erreur lors du chargement :", error);
+                });
+        },
+        // Regroupe les lignes (équipe × compte) par équipe ; user_id null => aucun compte.
+        groupByTeam(rows) {
+            const map = new Map();
+            rows.forEach((row) => {
+                if (!map.has(row.id_equipe)) {
+                    map.set(row.id_equipe, {
+                        id_equipe: row.id_equipe,
+                        team_full_name: row.team_full_name,
+                        leaders: [],
+                    });
+                }
+                if (row.user_id) {
+                    map.get(row.id_equipe).leaders.push({
+                        user_id: row.user_id,
+                        login: row.login,
+                        email: row.email,
+                    });
+                }
+            });
+            return Array.from(map.values());
+        },
+        handleSubmit() {
+            const formData = new FormData();
+            formData.append("id_equipe", this.newLink.id_equipe);
+            formData.append("email", this.newLink.email);
+            axios
+                .post(`/rest/action.php/usermanager/attachClubTeamLeader`, formData)
+                .then((response) => {
+                    onSuccess(this, response);
+                    this.fetchTeamLeaders();
+                    this.newLink = {id_equipe: '', email: ''};
+                })
+                .catch((error) => {
+                    onError(this, error);
+                });
+        },
+        onDetachClick(team, leader) {
+            const formData = new FormData();
+            formData.append("user_id", leader.user_id);
+            formData.append("id_equipe", team.id_equipe);
+            axios
+                .post(`/rest/action.php/usermanager/detachClubTeamLeader`, formData)
+                .then((response) => {
+                    onSuccess(this, response);
+                    this.fetchTeamLeaders();
+                })
+                .catch((error) => {
+                    onError(this, error);
+                });
+        },
+    },
+    created() {
+        this.fetchTeamLeaders();
+    },
+};

--- a/pages/components/panel/ClubTeamUnavailability.js
+++ b/pages/components/panel/ClubTeamUnavailability.js
@@ -1,0 +1,127 @@
+import {onError, onSuccess} from "../../../toaster.js";
+
+/**
+ * Issue #101 — Indisponibilités des équipes du club (responsable de club).
+ *
+ * Panneau club-scoped : le responsable de club déclare les dates où une de ses
+ * équipes ne peut pas jouer. Les endpoints REST (blacklistteam/*) restreignent
+ * côté serveur aux équipes du club.
+ */
+export default {
+    template: `
+      <div>
+        <p class="text-xl">Indisponibilités des équipes du club</p>
+        <p class="text-sm opacity-70 mb-4">
+          Déclarez les dates où une de vos équipes ne peut pas jouer.
+          Ces indisponibilités sont prises en compte lors de la génération du calendrier.
+        </p>
+        <div class="flex flex-wrap gap-2">
+          <div v-if="unavailabilities.length > 0" class="w-full">
+            <div class="bg-base-200 border border-2 border-base-300 p-4 flex flex-wrap gap-2">
+              <div v-for="item in unavailabilities" :key="item.id" class="card shadow-xl">
+                <div class="card-body">
+                  <h2 class="card-title"><i class="fas fa-ban mr-2"></i>{{ item.closed_date }}</h2>
+                  <p>{{ item.libelle_equipe }}</p>
+                </div>
+                <div class="card-actions justify-end mr-2 mb-2">
+                  <button class="btn btn-error" @click="onRemoveClick(item)">
+                    <i class="fas fa-trash mr-2"></i>supprimer
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div v-else class="alert alert-info w-full">
+            <span>Aucune indisponibilité déclarée pour les équipes de votre club.</span>
+          </div>
+          <div class="w-full">
+            <form class="flex flex-col gap-4 p-4 max-w-md mx-auto border rounded-lg shadow-lg"
+                  @submit.prevent="handleSubmit">
+              <label class="font-bold" for="equipe">Équipe</label>
+              <select id="equipe" name="id_team" v-model="newItem.id_team" required>
+                <option value="">Sélectionner une équipe</option>
+                <option v-for="team in clubTeams" :key="team.id_equipe" :value="team.id_equipe">
+                  {{ team.team_full_name }}
+                </option>
+              </select>
+
+              <label class="font-bold" for="closed_date">Date d'indisponibilité</label>
+              <input type="date" id="closed_date" name="closed_date" v-model="newItem.closed_date" required>
+
+              <button type="submit" class="btn btn-primary">Ajouter une indisponibilité</button>
+            </form>
+          </div>
+        </div>
+      </div>
+    `,
+    data() {
+        return {
+            clubTeams: [],
+            unavailabilities: [],
+            newItem: {id_team: '', closed_date: ''},
+            isLoading: false,
+        };
+    },
+    methods: {
+        fetchClubTeams() {
+            axios
+                .get("/rest/action.php/club/getMyClubTeams")
+                .then((response) => {
+                    this.clubTeams = response.data;
+                })
+                .catch((error) => {
+                    console.error("Erreur lors du chargement des équipes :", error);
+                });
+        },
+        fetchUnavailabilities() {
+            axios
+                .get("/rest/action.php/blacklistteam/getMyClubBlacklistTeam")
+                .then((response) => {
+                    this.unavailabilities = response.data;
+                })
+                .catch((error) => {
+                    console.error("Erreur lors du chargement des indisponibilités :", error);
+                });
+        },
+        // Convertit yyyy-mm-dd (input date) vers dd/mm/yyyy (attendu par le backend)
+        toFrenchDate(isoDate) {
+            if (!isoDate) {
+                return '';
+            }
+            const [y, m, d] = isoDate.split('-');
+            return `${d}/${m}/${y}`;
+        },
+        handleSubmit() {
+            const formData = new FormData();
+            formData.append("id_team", this.newItem.id_team);
+            formData.append("closed_date", this.toFrenchDate(this.newItem.closed_date));
+            axios
+                .post(`/rest/action.php/blacklistteam/saveBlacklistTeam`, formData)
+                .then((response) => {
+                    onSuccess(this, response);
+                    this.fetchUnavailabilities();
+                    this.newItem = {id_team: '', closed_date: ''};
+                })
+                .catch((error) => {
+                    onError(this, error);
+                });
+        },
+        onRemoveClick(item) {
+            const formData = new FormData();
+            formData.append("id", item.id);
+            axios
+                .post(`/rest/action.php/blacklistteam/removeBlacklistTeam`, formData)
+                .then((response) => {
+                    onSuccess(this, response);
+                    this.fetchUnavailabilities();
+                })
+                .catch((error) => {
+                    onError(this, error);
+                });
+        },
+    },
+    created() {
+        this.fetchClubTeams();
+        this.fetchUnavailabilities();
+    },
+};

--- a/pages/components/panel/ClubTeamUnavailability.js
+++ b/pages/components/panel/ClubTeamUnavailability.js
@@ -41,7 +41,7 @@ export default {
               <select id="equipe" name="id_team" v-model="newItem.id_team" required>
                 <option value="">Sélectionner une équipe</option>
                 <option v-for="team in clubTeams" :key="team.id_equipe" :value="team.id_equipe">
-                  {{ team.team_full_name }}
+                  {{ team.team_full_name }}{{ parseInt(team.nb_competitions) > 0 ? '' : ' — non engagée' }}
                 </option>
               </select>
 

--- a/pages/components/panel/TeamLeaderDashboard.js
+++ b/pages/components/panel/TeamLeaderDashboard.js
@@ -5,10 +5,77 @@ export default {
         'team-leader-infos': defineAsyncComponent(() => import('./TeamLeaderInfos.js')),
         'team-leader-alerts': defineAsyncComponent(() => import('./TeamLeaderAlerts.js'))
     },
+    data() {
+        return {
+            isClubLeader: false,
+            isActingAs: false,
+            loaded: false,
+        };
+    },
+    methods: {
+        fetchSession() {
+            axios.get('/session_user.php')
+                .then((response) => {
+                    if (response.data && !response.data.error) {
+                        this.isClubLeader = response.data.profile_name === 'RESPONSABLE_CLUB';
+                        this.isActingAs = response.data.is_acting_as === true;
+                    }
+                })
+                .catch(() => {})
+                .finally(() => {
+                    this.loaded = true;
+                });
+        },
+    },
+    created() {
+        this.fetchSession();
+    },
+    // Pour un responsable de club (hors act-as), le tableau de bord est orienté
+    // « club » : il gère ses équipes en cliquant « gérer une équipe » (navbar) et
+    // accède aux actions transverses ci-dessous. Sinon, dashboard équipe habituel.
     template: `
       <div>
-        <team-leader-alerts></team-leader-alerts>
-        <team-leader-infos></team-leader-infos>
+        <div v-if="!loaded" class="flex justify-center p-8">
+          <span class="loading loading-spinner loading-lg"></span>
+        </div>
+        <div v-else-if="isClubLeader">
+          <h1 class="text-2xl font-bold mb-2"><i class="fas fa-people-group mr-2"></i>Espace responsable de club</h1>
+          <p class="opacity-70 mb-6">
+            Gérez les comptes et les contraintes de votre club ci-dessous. Pour gérer le détail
+            d'une équipe (effectif, créneaux, matchs, coordonnées), utilisez
+            <strong>« gérer une équipe »</strong> dans le menu : vous agirez alors en tant que son responsable.
+          </p>
+          <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <router-link to="/club_team_leaders" class="card bg-base-100 shadow-xl hover:shadow-2xl transition">
+              <div class="card-body">
+                <h2 class="card-title"><i class="fas fa-user-gear mr-2"></i>Comptes responsables</h2>
+                <p>Créer et rattacher un compte responsable à chaque équipe du club.</p>
+              </div>
+            </router-link>
+            <router-link to="/club_gymnasium_closures" class="card bg-base-100 shadow-xl hover:shadow-2xl transition">
+              <div class="card-body">
+                <h2 class="card-title"><i class="fas fa-lock mr-2"></i>Fermetures gymnases</h2>
+                <p>Déclarer les dates de fermeture des gymnases de vos équipes.</p>
+              </div>
+            </router-link>
+            <router-link to="/club_team_unavailability" class="card bg-base-100 shadow-xl hover:shadow-2xl transition">
+              <div class="card-body">
+                <h2 class="card-title"><i class="fas fa-ban mr-2"></i>Indispos équipes</h2>
+                <p>Déclarer les dates où une équipe du club ne peut pas jouer.</p>
+              </div>
+            </router-link>
+            <router-link to="/club_matchs" class="card bg-base-100 shadow-xl hover:shadow-2xl transition">
+              <div class="card-body">
+                <h2 class="card-title"><i class="fas fa-volleyball mr-2"></i>Matchs du club</h2>
+                <p>Consulter l'ensemble des matchs des équipes du club.</p>
+              </div>
+            </router-link>
+          </div>
+        </div>
+        <div v-else>
+          <team-leader-alerts></team-leader-alerts>
+          <team-leader-infos></team-leader-infos>
+        </div>
       </div>
     `
 };

--- a/unit_tests/ClubLeaderTest.php
+++ b/unit_tests/ClubLeaderTest.php
@@ -4,6 +4,7 @@ require_once __DIR__ . '/../classes/UserManager.php';
 require_once __DIR__ . '/../classes/Club.php';
 require_once __DIR__ . '/../classes/TimeSlot.php';
 require_once __DIR__ . '/../classes/BlackListCourt.php';
+require_once __DIR__ . '/../classes/BlackListTeam.php';
 require_once __DIR__ . '/../classes/SqlManager.php';
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/UfolepTestCase.php';
@@ -189,5 +190,39 @@ class ClubLeaderTest extends UfolepTestCase
             return $r['id'] === $created['id'];
         });
         $this->assertEmpty($stillThere, "La fermeture doit avoir été supprimée");
+    }
+
+    // ---- Phase c : indisponibilités des équipes du club -------------------
+
+    public function test_saveBlacklistTeam_refuses_team_outside_club()
+    {
+        if ($this->foreign_team_id === null) {
+            $this->markTestSkipped("Pas d'équipe hors club disponible");
+        }
+        $this->connect_as_club_leader($this->id_club, $this->club_team_ids[0]);
+        $blacklist = new BlackListTeam();
+        $this->expectException(Exception::class);
+        $blacklist->saveBlacklistTeam($this->foreign_team_id, '03/01/2099');
+    }
+
+    public function test_club_leader_blacklist_team_roundtrip()
+    {
+        $this->connect_as_club_leader($this->id_club, $this->club_team_ids[0]);
+        $blacklist = new BlackListTeam();
+        $teamId = $this->club_team_ids[0];
+        $closedDate = '04/01/2099';
+        $blacklist->saveBlacklistTeam($teamId, $closedDate);
+        $rows = $blacklist->getMyClubBlacklistTeam();
+        $match = array_filter($rows, static function ($r) use ($teamId, $closedDate) {
+            return (int)$r['id_team'] === $teamId && $r['closed_date'] === $closedDate;
+        });
+        $this->assertNotEmpty($match, "L'indisponibilité créée doit apparaître dans la vue club");
+        $created = array_values($match)[0];
+        $blacklist->removeBlacklistTeam($created['id']);
+        $rowsAfter = $blacklist->getMyClubBlacklistTeam();
+        $stillThere = array_filter($rowsAfter, static function ($r) use ($created) {
+            return $r['id'] === $created['id'];
+        });
+        $this->assertEmpty($stillThere, "L'indisponibilité doit avoir été supprimée");
     }
 }

--- a/unit_tests/ClubLeaderTest.php
+++ b/unit_tests/ClubLeaderTest.php
@@ -1,0 +1,123 @@
+<?php
+
+require_once __DIR__ . '/../classes/UserManager.php';
+require_once __DIR__ . '/../classes/Club.php';
+require_once __DIR__ . '/../classes/TimeSlot.php';
+require_once __DIR__ . '/../classes/SqlManager.php';
+require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/UfolepTestCase.php';
+
+/**
+ * Issue #101 — socle du profil RESPONSABLE_CLUB.
+ *
+ * Un RESPONSABLE_CLUB gère toutes les équipes de son club. Le socle :
+ *  - UserManager::isClubLeader() / isTeamManager() (responsable d'équipe OU de club)
+ *  - Club::getMyClubId() résout le club depuis la session (posée au login depuis users_clubs)
+ *  - Club::getMyClubTeams() liste les équipes du club
+ *  - UserManager::switchCurrentUserTeam() autorise le club leader à basculer
+ *    sur n'importe quelle équipe de SON club, et refuse les autres
+ *  - les créneaux (TimeSlot) deviennent gérables par le club leader sur l'équipe
+ *    sélectionnée
+ */
+class ClubLeaderTest extends UfolepTestCase
+{
+    private ?int $id_club = null;
+    private array $club_team_ids = [];
+    private ?int $foreign_team_id = null;
+
+    public function __construct()
+    {
+        parent::__construct();
+        // Choisit dynamiquement un club ayant au moins 2 équipes
+        $rows = $this->sql->execute(
+            "SELECT e.id_club, COUNT(*) AS nb
+             FROM equipes e
+             JOIN clubs c ON c.id = e.id_club
+             GROUP BY e.id_club
+             HAVING nb >= 2
+             ORDER BY nb DESC
+             LIMIT 1"
+        );
+        if (count($rows) > 0) {
+            $this->id_club = (int)$rows[0]['id_club'];
+            $teamRows = $this->sql->execute(
+                "SELECT id_equipe FROM equipes WHERE id_club = " . $this->id_club . " ORDER BY id_equipe"
+            );
+            $this->club_team_ids = array_map('intval', array_column($teamRows, 'id_equipe'));
+            $foreignRows = $this->sql->execute(
+                "SELECT id_equipe FROM equipes WHERE id_club <> " . $this->id_club . " LIMIT 1"
+            );
+            if (count($foreignRows) > 0) {
+                $this->foreign_team_id = (int)$foreignRows[0]['id_equipe'];
+            }
+        }
+    }
+
+    public function test_isClubLeader_true_when_club_leader_connected()
+    {
+        $this->connect_as_club_leader($this->id_club, $this->club_team_ids[0]);
+        $this->assertTrue(UserManager::isClubLeader());
+        $this->assertFalse(UserManager::isTeamLeader());
+    }
+
+    public function test_isTeamManager_true_for_both_team_and_club_leaders()
+    {
+        $this->connect_as_team_leader($this->club_team_ids[0]);
+        $this->assertTrue(UserManager::isTeamManager());
+
+        $this->connect_as_club_leader($this->id_club, $this->club_team_ids[0]);
+        $this->assertTrue(UserManager::isTeamManager());
+
+        $this->connect_as_admin();
+        $this->assertFalse(UserManager::isTeamManager());
+    }
+
+    public function test_getMyClubTeams_returns_only_teams_of_the_club()
+    {
+        $this->connect_as_club_leader($this->id_club, $this->club_team_ids[0]);
+        $club = new Club();
+        $teams = $club->getMyClubTeams();
+        $this->assertNotEmpty($teams);
+        $returnedIds = array_map('intval', array_column($teams, 'id_equipe'));
+        sort($returnedIds);
+        $expected = $this->club_team_ids;
+        sort($expected);
+        $this->assertEquals($expected, $returnedIds);
+    }
+
+    public function test_getMyClubId_reads_session_club()
+    {
+        $this->connect_as_club_leader($this->id_club, $this->club_team_ids[0]);
+        $club = new Club();
+        $this->assertEquals($this->id_club, $club->getMyClubId());
+    }
+
+    public function test_switchCurrentUserTeam_allows_team_of_own_club()
+    {
+        $target = $this->club_team_ids[1];
+        $this->connect_as_club_leader($this->id_club, $this->club_team_ids[0]);
+        $userManager = new UserManager();
+        $userManager->switchCurrentUserTeam($target);
+        $this->assertEquals($target, $_SESSION['id_equipe']);
+    }
+
+    public function test_switchCurrentUserTeam_refuses_foreign_team()
+    {
+        if ($this->foreign_team_id === null) {
+            $this->markTestSkipped("Pas d'équipe hors club disponible");
+        }
+        $this->connect_as_club_leader($this->id_club, $this->club_team_ids[0]);
+        $userManager = new UserManager();
+        $this->expectException(Exception::class);
+        $userManager->switchCurrentUserTeam($this->foreign_team_id);
+    }
+
+    public function test_club_leader_can_read_timeslots_of_selected_team()
+    {
+        $this->connect_as_club_leader($this->id_club, $this->club_team_ids[0]);
+        $timeSlot = new TimeSlot();
+        // ne doit pas lever d'exception d'autorisation
+        $result = $timeSlot->get_my_timeslots();
+        $this->assertIsArray($result);
+    }
+}

--- a/unit_tests/ClubLeaderTest.php
+++ b/unit_tests/ClubLeaderTest.php
@@ -82,18 +82,6 @@ class ClubLeaderTest extends UfolepTestCase
         $this->assertFalse(UserManager::isTeamLeader());
     }
 
-    public function test_isTeamManager_true_for_both_team_and_club_leaders()
-    {
-        $this->connect_as_team_leader($this->club_team_ids[0]);
-        $this->assertTrue(UserManager::isTeamManager());
-
-        $this->connect_as_club_leader($this->id_club, $this->club_team_ids[0]);
-        $this->assertTrue(UserManager::isTeamManager());
-
-        $this->connect_as_admin();
-        $this->assertFalse(UserManager::isTeamManager());
-    }
-
     public function test_getMyClubTeams_returns_only_teams_of_the_club()
     {
         $this->connect_as_club_leader($this->id_club, $this->club_team_ids[0]);
@@ -112,35 +100,6 @@ class ClubLeaderTest extends UfolepTestCase
         $this->connect_as_club_leader($this->id_club, $this->club_team_ids[0]);
         $club = new Club();
         $this->assertEquals($this->id_club, $club->getMyClubId());
-    }
-
-    public function test_switchCurrentUserTeam_allows_team_of_own_club()
-    {
-        $target = $this->club_team_ids[1];
-        $this->connect_as_club_leader($this->id_club, $this->club_team_ids[0]);
-        $userManager = new UserManager();
-        $userManager->switchCurrentUserTeam($target);
-        $this->assertEquals($target, $_SESSION['id_equipe']);
-    }
-
-    public function test_switchCurrentUserTeam_refuses_foreign_team()
-    {
-        if ($this->foreign_team_id === null) {
-            $this->markTestSkipped("Pas d'équipe hors club disponible");
-        }
-        $this->connect_as_club_leader($this->id_club, $this->club_team_ids[0]);
-        $userManager = new UserManager();
-        $this->expectException(Exception::class);
-        $userManager->switchCurrentUserTeam($this->foreign_team_id);
-    }
-
-    public function test_club_leader_can_read_timeslots_of_selected_team()
-    {
-        $this->connect_as_club_leader($this->id_club, $this->club_team_ids[0]);
-        $timeSlot = new TimeSlot();
-        // ne doit pas lever d'exception d'autorisation
-        $result = $timeSlot->get_my_timeslots();
-        $this->assertIsArray($result);
     }
 
     // ---- Phase b : fermetures des gymnases du club -------------------------
@@ -259,5 +218,78 @@ class ClubLeaderTest extends UfolepTestCase
         $userManager = new UserManager();
         $this->expectException(Exception::class);
         $userManager->detachClubTeamLeader(1, $this->foreign_team_id);
+    }
+
+    // ---- Phase d : agir en tant qu'un responsable d'équipe du club --------
+
+    public function test_switch_to_club_team_leader_succeeds_and_switch_back_restores_club()
+    {
+        $row = $this->sql->execute(
+            "SELECT e.id_club, ut.user_id, ut.team_id
+             FROM users_teams ut
+             JOIN equipes e ON e.id_equipe = ut.team_id
+             JOIN users_profiles up ON up.user_id = ut.user_id
+             JOIN profiles p ON p.id = up.profile_id AND p.name = 'RESPONSABLE_EQUIPE'
+             LIMIT 1"
+        );
+        if (count($row) === 0) {
+            $this->markTestSkipped("Aucun compte responsable d'équipe disponible");
+        }
+        $clubId = (int)$row[0]['id_club'];
+        $targetUserId = (int)$row[0]['user_id'];
+
+        $this->connect_as_club_leader($clubId);
+        $userManager = new UserManager();
+        $userManager->switch_to_club_team_leader($targetUserId);
+
+        $this->assertTrue(UserManager::is_acting_as());
+        $this->assertEquals($targetUserId, $_SESSION['id_user']);
+        $this->assertEquals('RESPONSABLE_EQUIPE', $_SESSION['profile_name']);
+        // l'équipe ciblée appartient au club
+        $clubTeamIds = array_map('intval', array_column(
+            $this->sql->execute("SELECT id_equipe FROM equipes WHERE id_club = $clubId"), 'id_equipe'));
+        $this->assertContains((int)$_SESSION['id_equipe'], $clubTeamIds);
+
+        // retour : on retrouve le compte club
+        $userManager->switch_back_to_admin();
+        $this->assertFalse(UserManager::is_acting_as());
+        $this->assertEquals('RESPONSABLE_CLUB', $_SESSION['profile_name']);
+        $this->assertEquals($clubId, $_SESSION['id_club']);
+    }
+
+    public function test_switch_to_club_team_leader_refuses_account_outside_club()
+    {
+        $clubRow = $this->sql->execute(
+            "SELECT e.id_club
+             FROM users_teams ut
+             JOIN equipes e ON e.id_equipe = ut.team_id
+             JOIN users_profiles up ON up.user_id = ut.user_id
+             JOIN profiles p ON p.id = up.profile_id AND p.name = 'RESPONSABLE_EQUIPE'
+             LIMIT 1"
+        );
+        if (count($clubRow) === 0) {
+            $this->markTestSkipped("Aucun compte responsable d'équipe disponible");
+        }
+        $clubId = (int)$clubRow[0]['id_club'];
+        $foreign = $this->sql->execute(
+            "SELECT ut.user_id
+             FROM users_teams ut
+             JOIN equipes e ON e.id_equipe = ut.team_id
+             JOIN users_profiles up ON up.user_id = ut.user_id
+             JOIN profiles p ON p.id = up.profile_id AND p.name = 'RESPONSABLE_EQUIPE'
+             WHERE e.id_club <> $clubId
+               AND ut.user_id NOT IN (
+                   SELECT ut2.user_id FROM users_teams ut2
+                   JOIN equipes e2 ON e2.id_equipe = ut2.team_id
+                   WHERE e2.id_club = $clubId)
+             LIMIT 1"
+        );
+        if (count($foreign) === 0) {
+            $this->markTestSkipped("Aucun compte responsable hors club disponible");
+        }
+        $this->connect_as_club_leader($clubId);
+        $userManager = new UserManager();
+        $this->expectException(Exception::class);
+        $userManager->switch_to_club_team_leader((int)$foreign[0]['user_id']);
     }
 }

--- a/unit_tests/ClubLeaderTest.php
+++ b/unit_tests/ClubLeaderTest.php
@@ -225,4 +225,39 @@ class ClubLeaderTest extends UfolepTestCase
         });
         $this->assertEmpty($stillThere, "L'indisponibilité doit avoir été supprimée");
     }
+
+    // ---- Phase e : attribution des comptes RESPONSABLE_EQUIPE -------------
+
+    public function test_getMyClubTeamLeaders_returns_only_club_teams()
+    {
+        $this->connect_as_club_leader($this->id_club, $this->club_team_ids[0]);
+        $userManager = new UserManager();
+        $rows = $userManager->getMyClubTeamLeaders();
+        $this->assertNotEmpty($rows);
+        foreach ($rows as $row) {
+            $this->assertContains((int)$row['id_equipe'], $this->club_team_ids);
+        }
+    }
+
+    public function test_attachClubTeamLeader_refuses_team_outside_club()
+    {
+        if ($this->foreign_team_id === null) {
+            $this->markTestSkipped("Pas d'équipe hors club disponible");
+        }
+        $this->connect_as_club_leader($this->id_club, $this->club_team_ids[0]);
+        $userManager = new UserManager();
+        $this->expectException(Exception::class);
+        $userManager->attachClubTeamLeader('ne.doit.pas.etre.cree@ufolep13.test', $this->foreign_team_id);
+    }
+
+    public function test_detachClubTeamLeader_refuses_team_outside_club()
+    {
+        if ($this->foreign_team_id === null) {
+            $this->markTestSkipped("Pas d'équipe hors club disponible");
+        }
+        $this->connect_as_club_leader($this->id_club, $this->club_team_ids[0]);
+        $userManager = new UserManager();
+        $this->expectException(Exception::class);
+        $userManager->detachClubTeamLeader(1, $this->foreign_team_id);
+    }
 }

--- a/unit_tests/ClubLeaderTest.php
+++ b/unit_tests/ClubLeaderTest.php
@@ -3,6 +3,7 @@
 require_once __DIR__ . '/../classes/UserManager.php';
 require_once __DIR__ . '/../classes/Club.php';
 require_once __DIR__ . '/../classes/TimeSlot.php';
+require_once __DIR__ . '/../classes/BlackListCourt.php';
 require_once __DIR__ . '/../classes/SqlManager.php';
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/UfolepTestCase.php';
@@ -24,15 +25,19 @@ class ClubLeaderTest extends UfolepTestCase
     private ?int $id_club = null;
     private array $club_team_ids = [];
     private ?int $foreign_team_id = null;
+    private array $club_gymnasium_ids = [];
+    private ?int $foreign_gymnasium_id = null;
 
     public function __construct()
     {
         parent::__construct();
-        // Choisit dynamiquement un club ayant au moins 2 équipes
+        // Choisit dynamiquement un club ayant au moins 2 équipes ET des créneaux
+        // (donc des gymnases), pour couvrir aussi la gestion des fermetures.
         $rows = $this->sql->execute(
-            "SELECT e.id_club, COUNT(*) AS nb
+            "SELECT e.id_club, COUNT(DISTINCT e.id_equipe) AS nb
              FROM equipes e
              JOIN clubs c ON c.id = e.id_club
+             JOIN creneau cr ON cr.id_equipe = e.id_equipe
              GROUP BY e.id_club
              HAVING nb >= 2
              ORDER BY nb DESC
@@ -49,6 +54,22 @@ class ClubLeaderTest extends UfolepTestCase
             );
             if (count($foreignRows) > 0) {
                 $this->foreign_team_id = (int)$foreignRows[0]['id_equipe'];
+            }
+            $gymRows = $this->sql->execute(
+                "SELECT DISTINCT cr.id_gymnase
+                 FROM creneau cr
+                 JOIN equipes e ON e.id_equipe = cr.id_equipe
+                 WHERE e.id_club = " . $this->id_club
+            );
+            $this->club_gymnasium_ids = array_map('intval', array_column($gymRows, 'id_gymnase'));
+            if (count($this->club_gymnasium_ids) > 0) {
+                $idsCsv = implode(',', $this->club_gymnasium_ids);
+                $foreignGym = $this->sql->execute(
+                    "SELECT id FROM gymnase WHERE id NOT IN ($idsCsv) LIMIT 1"
+                );
+                if (count($foreignGym) > 0) {
+                    $this->foreign_gymnasium_id = (int)$foreignGym[0]['id'];
+                }
             }
         }
     }
@@ -119,5 +140,54 @@ class ClubLeaderTest extends UfolepTestCase
         // ne doit pas lever d'exception d'autorisation
         $result = $timeSlot->get_my_timeslots();
         $this->assertIsArray($result);
+    }
+
+    // ---- Phase b : fermetures des gymnases du club -------------------------
+
+    public function test_getMyClubGymnasiums_returns_gyms_used_by_club()
+    {
+        $this->connect_as_club_leader($this->id_club, $this->club_team_ids[0]);
+        $blacklist = new BlackListCourt();
+        $gyms = $blacklist->getMyClubGymnasiums();
+        $this->assertNotEmpty($gyms);
+        $returnedIds = array_map('intval', array_column($gyms, 'id'));
+        sort($returnedIds);
+        $expected = $this->club_gymnasium_ids;
+        sort($expected);
+        $this->assertEquals($expected, $returnedIds);
+    }
+
+    public function test_saveBlacklistGymnase_refuses_gym_outside_club()
+    {
+        if ($this->foreign_gymnasium_id === null) {
+            $this->markTestSkipped("Pas de gymnase hors club disponible");
+        }
+        $this->connect_as_club_leader($this->id_club, $this->club_team_ids[0]);
+        $blacklist = new BlackListCourt();
+        $this->expectException(Exception::class);
+        $blacklist->saveBlacklistGymnase($this->foreign_gymnasium_id, '01/01/2099');
+    }
+
+    public function test_club_leader_blacklist_gymnase_roundtrip()
+    {
+        $this->connect_as_club_leader($this->id_club, $this->club_team_ids[0]);
+        $blacklist = new BlackListCourt();
+        $gymId = $this->club_gymnasium_ids[0];
+        $closedDate = '02/01/2099';
+        $blacklist->saveBlacklistGymnase($gymId, $closedDate);
+        // la fermeture apparaît dans la vue club
+        $rows = $blacklist->getMyClubBlacklistGymnase();
+        $match = array_filter($rows, static function ($r) use ($gymId, $closedDate) {
+            return (int)$r['id_gymnase'] === $gymId && $r['closed_date'] === $closedDate;
+        });
+        $this->assertNotEmpty($match, "La fermeture créée doit apparaître dans la vue club");
+        // nettoyage : suppression par le club leader
+        $created = array_values($match)[0];
+        $blacklist->removeBlacklistGymnase($created['id']);
+        $rowsAfter = $blacklist->getMyClubBlacklistGymnase();
+        $stillThere = array_filter($rowsAfter, static function ($r) use ($created) {
+            return $r['id'] === $created['id'];
+        });
+        $this->assertEmpty($stillThere, "La fermeture doit avoir été supprimée");
     }
 }

--- a/unit_tests/ClubLeaderTest.php
+++ b/unit_tests/ClubLeaderTest.php
@@ -88,6 +88,9 @@ class ClubLeaderTest extends UfolepTestCase
         $club = new Club();
         $teams = $club->getMyClubTeams();
         $this->assertNotEmpty($teams);
+        // indicateur d'engagement (compétitions de la saison)
+        $this->assertArrayHasKey('nb_competitions', $teams[0]);
+        $this->assertArrayHasKey('competitions', $teams[0]);
         $returnedIds = array_map('intval', array_column($teams, 'id_equipe'));
         sort($returnedIds);
         $expected = $this->club_team_ids;

--- a/unit_tests/UfolepTestCase.php
+++ b/unit_tests/UfolepTestCase.php
@@ -31,6 +31,16 @@ class UfolepTestCase extends TestCase
         $_SESSION['profile_name'] = 'RESPONSABLE_EQUIPE';
     }
 
+    protected function connect_as_club_leader(mixed $id_club, mixed $id_equipe = null)
+    {
+        @session_start();
+        $_SESSION['id_club'] = $id_club;
+        $_SESSION['id_equipe'] = $id_equipe;
+        $_SESSION['login'] = 'test_user';
+        $_SESSION['id_user'] = 1;
+        $_SESSION['profile_name'] = 'RESPONSABLE_CLUB';
+    }
+
     protected function tearDown(): void
     {
         $_SESSION = [];


### PR DESCRIPTION
## Description

Résout #101 — donne de vrais pouvoirs au profil **RESPONSABLE_CLUB**, qui jusqu'ici ne différait quasiment pas d'un RESPONSABLE_EQUIPE.

Le compte responsable de club dispose désormais d'un **tableau de bord club** et gère son club selon deux modes :

- **Actions transverses au club, en direct** (en tant que RESPONSABLE_CLUB) :
  - fermetures des gymnases utilisés par ses équipes (`blacklist_gymnase`)
  - dates où une de ses équipes ne peut pas jouer (`blacklist_team`)
  - attribution des comptes responsables d'équipe (créer + rattacher, avec email de bienvenue)
  - consultation des matchs du club
- **Gestion détaillée d'une équipe, via « agir en tant que »** : le responsable de club incarne le compte RESPONSABLE_EQUIPE de l'équipe choisie (mécanisme réutilisé de l'« act as » admin). Il accède alors à toute l'UI responsable existante (effectif, créneaux, coordonnées, matchs) **sans qu'aucune garde d'autorisation n'ait été modifiée**, puis revient à son compte club via une bannière dédiée.

Le rattachement club ↔ utilisateur s'appuie sur la table existante `users_clubs`.

## Changements

**Backend**
- `UserManager` : `isClubLeader()`, résolution du club au login (`users_clubs` → `id_club` en session), `getMyClubTeamLeaders()` / `attachClubTeamLeader()` / `detachClubTeamLeader()` (attribution des comptes, scope club), `switch_to_club_team_leader()` (act-as d'un responsable d'équipe **du club**), `switch_back_to_admin()` généralisé pour restaurer aussi `id_club`.
- `Club` : `getMyClubId()`, `getMyClubTeams()`, `assertManagesTeam()`.
- `BlackListCourt` : `getMyClubGymnasiums()`, `getMyClubBlacklistGymnase()`, `removeBlacklistGymnase()`, scope club sur `saveBlacklistGymnase()` (chemin admin inchangé).
- `BlackListTeam` : `getMyClubBlacklistTeam()`, `removeBlacklistTeam()`, scope club sur `saveBlacklistTeam()` (chemin admin inchangé).
- `MatchMgr::getMyClubMatches()` : résout le club via `id_club` pour un responsable de club.

**Frontend (Vue 3 / Vite)**
- Navbar responsable : menu **« gérer une équipe »** (liste des comptes responsables du club à incarner), bannière **« revenir au compte club »** en mode act-as, menus per-équipe masqués pour le compte club hors act-as, menu **« gestion club »**.
- Nouveaux panneaux club : `ClubGymnasiumClosures.js`, `ClubTeamUnavailability.js`, `ClubTeamLeaders.js` + routes associées.
- `TeamLeaderDashboard.js` : tableau de bord orienté club pour un RESPONSABLE_CLUB.

## Tests
- [x] `unit_tests/ClubLeaderTest.php` — 13 tests (résolution club, scope des fermetures/indispos, attribution des comptes, act-as autorisé/refusé + retour qui restaure le club).
- [x] `unit_tests/ActAsTest.php` — 9 tests (act-as admin) inchangés et verts (non-régression).
- [x] Parcours vérifié en navigateur sur un club actif (Fuveau) : dashboard club, picker des comptes, act-as → créneaux/effectif, retour au compte club.

## Notes
- Pour le détail d'une équipe sans compte responsable rattaché, créer d'abord le compte via « gestion club › comptes responsables », puis l'incarner.
- `dist/` non versionné : rebuild via le CI (multi-stage `node:20`) comme d'habitude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
