### PR TITLE
feat: bilan annuel téléchargeable en PDF depuis l'admin

### DIFF
--- a/bilanPdf.php
+++ b/bilanPdf.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Genere le "Bilan d'activites" annuel au format PDF.
+ *
+ * Les chiffres sont RECALCULES cote serveur a partir de la saison (non
+ * falsifiables) ; seuls les commentaires libres proviennent du formulaire.
+ * Reserve aux administrateurs.
+ */
+
+require_once __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/classes/UserManager.php';
+require_once __DIR__ . '/classes/Bilan.php';
+
+use Fpdf\Fpdf;
+
+/** Convertit une chaine UTF-8 vers l'encodage attendu par FPDF (cp1252). */
+function toWellFormatted($string): string
+{
+    return !empty($string) ? iconv('UTF-8', 'windows-1252//TRANSLIT', $string) : '';
+}
+
+if (!UserManager::isAdmin()) {
+    http_response_code(403);
+    die('Acces refuse.');
+}
+
+try {
+    $saison = filter_input(INPUT_POST, 'saison', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+    $responsable = filter_input(INPUT_POST, 'responsable', FILTER_SANITIZE_FULL_SPECIAL_CHARS) ?: ($_SESSION['login'] ?? '');
+    $types_public = filter_input(INPUT_POST, 'types_public') ?: '';
+    $formations = filter_input(INPUT_POST, 'formations') ?: '';
+    $reunions = filter_input(INPUT_POST, 'reunions') ?: '';
+    $impression_generale = filter_input(INPUT_POST, 'impression_generale') ?: '';
+    $coupe_nationale = filter_input(INPUT_POST, 'coupe_nationale') ?: '';
+    $axes_amelioration = filter_input(INPUT_POST, 'axes_amelioration') ?: '';
+
+    $bilan = new Bilan();
+    $data = $bilan->getBilanData($saison);
+
+    $pdf = new FPDF();
+    $pdf->SetMargins(15, 12, 15);
+    $pdf->SetAutoPageBreak(true, 15);
+    $pdf->AddPage();
+
+    // --- helpers de mise en page --------------------------------------------
+    $sectionTitle = function (string $title) use ($pdf) {
+        $pdf->Ln(3);
+        $pdf->SetFont('Arial', 'B', 11);
+        $pdf->SetFillColor(230, 230, 230);
+        $pdf->Cell(0, 7, toWellFormatted($title), 0, 1, 'L', true);
+        $pdf->Ln(1);
+    };
+    $paragraph = function (string $text) use ($pdf) {
+        $pdf->SetFont('Arial', '', 10);
+        $pdf->MultiCell(0, 5, toWellFormatted($text !== '' ? $text : 'Néant'));
+    };
+
+    // --- en-tete ------------------------------------------------------------
+    $pdf->SetFont('Arial', 'B', 16);
+    $pdf->Cell(0, 10, toWellFormatted("BILAN D'ACTIVITÉS " . $data['saison']), 0, 1, 'C');
+    $pdf->Ln(2);
+    $pdf->SetFont('Arial', '', 11);
+    $pdf->Cell(0, 6, toWellFormatted('DISCIPLINE : Volley-ball'), 0, 1, 'L');
+    $pdf->Cell(0, 6, toWellFormatted('RESPONSABLE DE LA COMMISSION : ' . $responsable), 0, 1, 'L');
+
+    // --- manifestations, matchs ---------------------------------------------
+    $sectionTitle('MANIFESTATIONS, MATCHS, RENCONTRES');
+    $pdf->SetFont('Arial', 'B', 10);
+    $pdf->Cell(130, 7, toWellFormatted('Compétition'), 1, 0, 'L');
+    $pdf->Cell(0, 7, toWellFormatted('Nombre de matchs'), 1, 1, 'C');
+    $pdf->SetFont('Arial', '', 10);
+    foreach ($data['matchs'] as $ligne) {
+        $pdf->Cell(130, 6, toWellFormatted($ligne['competition']), 1, 0, 'L');
+        $pdf->Cell(0, 6, (int)$ligne['nb_matchs'], 1, 1, 'C');
+    }
+    $pdf->SetFont('Arial', 'B', 10);
+    $pdf->Cell(130, 7, 'TOTAL', 1, 0, 'L');
+    $pdf->Cell(0, 7, (int)$data['total_matchs'], 1, 1, 'C');
+
+    // --- clubs / licencies --------------------------------------------------
+    $sectionTitle('NOMBRE DE CLUBS PARTICIPANT');
+    $paragraph($data['nb_clubs'] . ' clubs');
+
+    $sectionTitle('NOMBRE DE LICENCIÉS PARTICIPANT');
+    $paragraph($data['nb_licencies'] . ' licenciés');
+
+    // --- sections libres ----------------------------------------------------
+    $sectionTitle('TYPES DE PUBLIC PARTICIPANT');
+    $paragraph($types_public);
+
+    $sectionTitle('FORMATIONS EFFECTUÉES');
+    $paragraph($formations);
+
+    $sectionTitle('RÉUNIONS STATUTAIRES / PARTICIPATION');
+    $paragraph($reunions);
+
+    $sectionTitle('IMPRESSION GÉNÉRALE SUR LA SAISON / BESOINS');
+    $paragraph($impression_generale);
+
+    // --- championnat departemental (chiffres base) --------------------------
+    $sectionTitle('CHAMPIONNAT DÉPARTEMENTAL');
+    $paragraph($data['nb_recompenses'] . ' équipes récompensées (1er et 2e de chaque division, '
+        . 'à mi-saison et en fin de saison, pour les 3 championnats)');
+    $paragraph($data['nb_coupes'] . ' coupe(s) décernée(s) :');
+    $pdf->SetFont('Arial', '', 10);
+    foreach ($data['coupes'] as $coupe) {
+        $pdf->Cell(6);
+        $pdf->MultiCell(0, 5, toWellFormatted('- ' . $coupe['recompense'] . ' : ' . $coupe['vainqueur']));
+    }
+
+    // --- coupe nationale / axes --------------------------------------------
+    $sectionTitle('COUPE NATIONALE');
+    $paragraph($coupe_nationale);
+
+    $sectionTitle("AXES D'AMÉLIORATION");
+    $paragraph($axes_amelioration);
+
+    $pdf->Output('D', 'Bilan ' . $data['saison'] . '.pdf');
+} catch (Exception $e) {
+    http_response_code(500);
+    echo 'Erreur lors de la génération du bilan : ' . $e->getMessage();
+}

--- a/classes/Bilan.php
+++ b/classes/Bilan.php
@@ -1,0 +1,181 @@
+<?php
+
+require_once __DIR__ . '/Generic.php';
+
+/**
+ * Bilan d'activites annuel.
+ *
+ * Fournit tous les chiffres du bilan officiel pour une saison donnee.
+ * Les definitions sont choisies pour rester reconstructibles sur une saison
+ * passee (matchs conserves en base, statut ARCHIVED) :
+ *  - "participant" = a joue au moins un match (matches / match_player) ;
+ *  - le filtre saison se fait uniquement par DATE, jamais par match_status.
+ *
+ * Conventions de periode dans hall_of_fame :
+ *  - championnats : 'AAAA-AAAA+1' (ex. '2025-2026') ;
+ *  - coupes       : annee civile des finales = 2e annee de la saison ('2026').
+ */
+class Bilan extends Generic
+{
+    /**
+     * Derive les bornes d'une saison "AAAA-AAAA+1".
+     *
+     * @return array{date_debut:string,date_fin:string,period_championnat:string,period_coupe:string}
+     * @throws Exception
+     */
+    public function getSeasonBounds(string $saison): array
+    {
+        if (!preg_match('/^(\d{4})-(\d{4})$/', trim($saison), $m)) {
+            throw new Exception("Format de saison invalide (attendu 'AAAA-AAAA', ex : 2025-2026).");
+        }
+        $y1 = (int)$m[1];
+        $y2 = (int)$m[2];
+        if ($y2 !== $y1 + 1) {
+            throw new Exception("Saison incoherente : la 2e annee doit suivre la 1ere (ex : 2025-2026).");
+        }
+        return array(
+            'date_debut' => sprintf('%04d-09-01', $y1),
+            'date_fin' => sprintf('%04d-06-30', $y2),
+            'period_championnat' => sprintf('%04d-%04d', $y1, $y2),
+            'period_coupe' => sprintf('%04d', $y2),
+        );
+    }
+
+    /**
+     * Renvoie l'ensemble des donnees chiffrees du bilan pour une saison.
+     *
+     * @throws Exception
+     */
+    public function getBilanData($saison = null): array
+    {
+        if (empty($saison)) {
+            throw new Exception("Saison manquante !");
+        }
+        $bounds = $this->getSeasonBounds($saison);
+        $matchs = $this->getMatchsParCompetition($bounds['date_debut'], $bounds['date_fin']);
+        $coupes = $this->getCoupes($bounds['period_coupe']);
+        $total_matchs = 0;
+        foreach ($matchs as $ligne) {
+            $total_matchs += (int)$ligne['nb_matchs'];
+        }
+        return array(
+            'saison' => $saison,
+            'date_debut' => $bounds['date_debut'],
+            'date_fin' => $bounds['date_fin'],
+            'matchs' => $matchs,
+            'total_matchs' => $total_matchs,
+            'nb_clubs' => $this->getNbClubsParticipants($bounds['date_debut'], $bounds['date_fin']),
+            'nb_licencies' => $this->getNbLicenciesParticipants($bounds['date_debut'], $bounds['date_fin']),
+            'nb_recompenses' => $this->getNbRecompensesChampionnat($bounds['period_championnat']),
+            'coupes' => $coupes,
+            'nb_coupes' => count($coupes),
+        );
+    }
+
+    /**
+     * Matchs joues par competition (coupes = poule + phases finales regroupees).
+     * Un match est "joue" s'il a un score saisi ou un forfait.
+     *
+     * @return array<array{competition:string,nb_matchs:int}>
+     * @throws Exception
+     */
+    public function getMatchsParCompetition(string $date_debut, string $date_fin): array
+    {
+        $sql = "SELECT CASE code
+                           WHEN 'm' THEN 'Championnat Masculin 6x6'
+                           WHEN 'f' THEN 'Championnat Féminin 4x4'
+                           WHEN 'mo' THEN 'Championnat Mixte 4x4'
+                           WHEN 'c' THEN 'Coupe Départementale Isoardi 6x6'
+                           WHEN 'kh' THEN 'Coupe Départementale Khoury Hanna 4x4'
+                           ELSE code END              AS competition,
+                       COUNT(*)                       AS nb_matchs
+                FROM (SELECT CASE
+                                 WHEN m.code_competition = 'cf' THEN 'c'
+                                 WHEN m.code_competition = 'kf' THEN 'kh'
+                                 ELSE m.code_competition END AS code
+                      FROM matchs_view m
+                      WHERE STR_TO_DATE(m.date_reception, '%d/%m/%Y') BETWEEN ? AND ?
+                        AND ((m.score_equipe_dom + m.score_equipe_ext) > 0
+                            OR m.forfait_dom = 1 OR m.forfait_ext = 1)) x
+                GROUP BY code
+                ORDER BY FIELD(code, 'm', 'f', 'mo', 'c', 'kh'), nb_matchs DESC";
+        return $this->sql_manager->execute($sql, array(
+            array('type' => 's', 'value' => $date_debut),
+            array('type' => 's', 'value' => $date_fin),
+        ));
+    }
+
+    /**
+     * Nombre de clubs ayant au moins une equipe ayant joue un match de championnat.
+     *
+     * @throws Exception
+     */
+    public function getNbClubsParticipants(string $date_debut, string $date_fin): int
+    {
+        $sql = "SELECT COUNT(DISTINCT e.id_club) AS nb
+                FROM matchs_view m
+                         JOIN equipes e ON e.id_equipe IN (m.id_equipe_dom, m.id_equipe_ext)
+                WHERE STR_TO_DATE(m.date_reception, '%d/%m/%Y') BETWEEN ? AND ?
+                  AND m.code_competition IN ('m', 'f', 'mo')";
+        $rows = $this->sql_manager->execute($sql, array(
+            array('type' => 's', 'value' => $date_debut),
+            array('type' => 's', 'value' => $date_fin),
+        ));
+        return (int)($rows[0]['nb'] ?? 0);
+    }
+
+    /**
+     * Nombre de licencies ayant figure sur au moins une feuille de match.
+     *
+     * @throws Exception
+     */
+    public function getNbLicenciesParticipants(string $date_debut, string $date_fin): int
+    {
+        $sql = "SELECT COUNT(DISTINCT mp.id_player) AS nb
+                FROM match_player mp
+                         JOIN matchs_view m ON m.id_match = mp.id_match
+                WHERE STR_TO_DATE(m.date_reception, '%d/%m/%Y') BETWEEN ? AND ?";
+        $rows = $this->sql_manager->execute($sql, array(
+            array('type' => 's', 'value' => $date_debut),
+            array('type' => 's', 'value' => $date_fin),
+        ));
+        return (int)($rows[0]['nb'] ?? 0);
+    }
+
+    /**
+     * Nombre d'equipes recompensees en championnat (1er + 2e, mi-saison + Dept.,
+     * par division, pour les 3 championnats).
+     *
+     * @throws Exception
+     */
+    public function getNbRecompensesChampionnat(string $period_championnat): int
+    {
+        $sql = "SELECT COUNT(*) AS nb
+                FROM hall_of_fame
+                WHERE period = ?
+                  AND (title LIKE 'Championne%' OR title LIKE 'Vice%')";
+        $rows = $this->sql_manager->execute($sql, array(
+            array('type' => 's', 'value' => $period_championnat),
+        ));
+        return (int)($rows[0]['nb'] ?? 0);
+    }
+
+    /**
+     * Liste des coupes decernees (vainqueurs), Trophee du fair-play inclus.
+     *
+     * @return array<array{recompense:string,vainqueur:string}>
+     * @throws Exception
+     */
+    public function getCoupes(string $period_coupe): array
+    {
+        $sql = "SELECT league    AS recompense,
+                       team_name AS vainqueur
+                FROM hall_of_fame
+                WHERE period = ?
+                  AND title = 'Vainqueur'
+                ORDER BY league";
+        return $this->sql_manager->execute($sql, array(
+            array('type' => 's', 'value' => $period_coupe),
+        ));
+    }
+}

--- a/js/administration.js
+++ b/js/administration.js
@@ -151,6 +151,11 @@ Ext.application({
                                         action: 'displayHallOfFame'
                                     },
                                     {
+                                        text: 'Bilan annuel',
+                                        glyph: 'xf1c1@FontAwesome',
+                                        action: 'displayBilan'
+                                    },
+                                    {
                                         text: 'Gestion des dates interdites par gymnase',
                                         action: 'displayBlacklistGymnase'
                                     },

--- a/js/controller/Administration.js
+++ b/js/controller/Administration.js
@@ -2,7 +2,7 @@ Ext.define('Ufolep13Volley.controller.Administration', {
     extend: 'Ext.app.Controller',
     stores: ['Players', 'Clubs', 'Teams', 'RankTeams', 'Competitions', 'ParentCompetitions', 'Profiles', 'Users', 'Gymnasiums', 'Activity', 'WeekSchedule', 'AdminMatches', 'AdminDays', 'LimitDates', 'AdminRanks', 'HallOfFame', 'Timeslots', 'BlacklistGymnase', 'BlacklistTeam', 'BlacklistTeams', 'BlacklistDate', 'Departements', 'AdminNews'],
     models: ['Player', 'Club', 'Team', 'RankTeam', 'Competition', 'Profile', 'User', 'Gymnasium', 'Activity', 'WeekSchedule', 'Match', 'WeekDay', 'Day', 'LimitDate', 'Rank', 'HallOfFame', 'Timeslot', 'BlacklistGymnase', 'BlacklistTeam', 'BlacklistTeams', 'BlacklistDate', 'News'],
-    views: ['player.Grid', 'player.Edit', 'club.Select', 'team.Select', 'team.Grid', 'team.Edit', 'match.AdminGrid', 'match.Edit', 'day.AdminGrid', 'day.Edit', 'limitdate.Grid', 'limitdate.Edit', 'profile.Grid', 'profile.Edit', 'profile.Select', 'user.Grid', 'user.Edit', 'gymnasium.Grid', 'gymnasium.Edit', 'club.Grid', 'club.Edit', 'activity.Grid', 'timeslot.WeekScheduleGrid', 'rank.AdminGrid', 'rank.Edit', 'rank.DragDropPanel', 'grid.HallOfFame', 'window.HallOfFame', 'grid.Competitions', 'window.Competition', 'grid.BlacklistGymnase', 'window.BlacklistGymnase', 'grid.BlacklistTeam', 'window.BlacklistTeam', 'grid.BlacklistTeams', 'window.BlacklistTeams', 'grid.BlacklistDate', 'window.BlacklistDate', 'grid.Timeslots', 'window.Timeslot', 'view.Indicators', 'news.AdminGrid', 'news.Edit'],
+    views: ['player.Grid', 'player.Edit', 'club.Select', 'team.Select', 'team.Grid', 'team.Edit', 'match.AdminGrid', 'match.Edit', 'day.AdminGrid', 'day.Edit', 'limitdate.Grid', 'limitdate.Edit', 'profile.Grid', 'profile.Edit', 'profile.Select', 'user.Grid', 'user.Edit', 'gymnasium.Grid', 'gymnasium.Edit', 'club.Grid', 'club.Edit', 'activity.Grid', 'timeslot.WeekScheduleGrid', 'rank.AdminGrid', 'rank.Edit', 'rank.DragDropPanel', 'grid.HallOfFame', 'window.HallOfFame', 'grid.Competitions', 'window.Competition', 'grid.BlacklistGymnase', 'window.BlacklistGymnase', 'grid.BlacklistTeam', 'window.BlacklistTeam', 'grid.BlacklistTeams', 'window.BlacklistTeams', 'grid.BlacklistDate', 'window.BlacklistDate', 'grid.Timeslots', 'window.Timeslot', 'view.Indicators', 'news.AdminGrid', 'news.Edit', 'bilan.Form'],
     refs: [{
         ref: 'ImagePlayer', selector: 'playeredit image'
     }, {
@@ -234,6 +234,12 @@ Ext.define('Ufolep13Volley.controller.Administration', {
                 click: this.displayIndicators
             }, 'menuitem[action=displayHallOfFame]': {
                 click: this.displayHallOfFame
+            }, 'menuitem[action=displayBilan]': {
+                click: this.displayBilan
+            }, 'button[action=loadBilanData]': {
+                click: this.loadBilanData
+            }, 'button[action=downloadBilanPdf]': {
+                click: this.downloadBilanPdf
             }, 'hall_of_fame_grid': {
                 added: this.addToolbarHallOfFame
             }, 'button[action=addHallOfFame]': {
@@ -1213,6 +1219,85 @@ Ext.define('Ufolep13Volley.controller.Administration', {
     },
     displayHallOfFame: function () {
         this.showAdministrationGrid('hall_of_fame_grid');
+    },
+    displayBilan: function () {
+        var mainPanel = this.getMainPanel();
+        var existing = Ext.ComponentQuery.query('bilanform');
+        var tab = existing.length > 0 ? existing[0] : mainPanel.add({xtype: 'bilanform'});
+        mainPanel.setActiveTab(tab);
+        var loadButton = tab.down('button[action=loadBilanData]');
+        if (loadButton) {
+            this.loadBilanData(loadButton);
+        }
+    },
+    buildBilanHtml: function (d) {
+        var rows = '';
+        Ext.each(d.matchs, function (m) {
+            rows += '<tr><td style="border:1px solid #ccc;padding:3px 8px;">' + m.competition
+                + '</td><td style="border:1px solid #ccc;padding:3px 8px;text-align:center;">' + m.nb_matchs + '</td></tr>';
+        });
+        var coupes = '';
+        Ext.each(d.coupes, function (c) {
+            coupes += '<li>' + c.recompense + ' : <b>' + c.vainqueur + '</b></li>';
+        });
+        return '' +
+            '<table style="border-collapse:collapse;margin-bottom:8px;">' +
+            '<tr><th style="border:1px solid #ccc;padding:3px 8px;text-align:left;">Compétition</th>' +
+            '<th style="border:1px solid #ccc;padding:3px 8px;">Nombre de matchs</th></tr>' +
+            rows +
+            '<tr><td style="border:1px solid #ccc;padding:3px 8px;"><b>TOTAL</b></td>' +
+            '<td style="border:1px solid #ccc;padding:3px 8px;text-align:center;"><b>' + d.total_matchs + '</b></td></tr>' +
+            '</table>' +
+            '<b>Clubs participants :</b> ' + d.nb_clubs + '<br/>' +
+            '<b>Licenciés participants :</b> ' + d.nb_licencies + '<br/>' +
+            '<b>Équipes récompensées (championnat) :</b> ' + d.nb_recompenses + '<br/>' +
+            '<b>Coupes décernées :</b> ' + d.nb_coupes +
+            '<ul style="margin:4px 0 0 0;">' + coupes + '</ul>';
+    },
+    loadBilanData: function (button) {
+        var this_controller = this;
+        var form = button.up('form');
+        var saisonField = form.getForm().findField('saison');
+        if (!saisonField.isValid()) {
+            Ext.Msg.alert('Erreur', "Saison invalide (format attendu : AAAA-AAAA, ex : 2025-2026).");
+            return;
+        }
+        var apercu = form.getForm().findField('apercu');
+        apercu.setValue('<em>Chargement…</em>');
+        Ext.Ajax.request({
+            url: '/rest/action.php/bilan/getBilanData',
+            method: 'GET',
+            params: {saison: saisonField.getValue()},
+            success: function (response) {
+                var d = Ext.decode(response.responseText);
+                apercu.setValue(this_controller.buildBilanHtml(d));
+            },
+            failure: this_controller.manage_failure
+        });
+    },
+    downloadBilanPdf: function (button) {
+        var form = button.up('form');
+        var saisonField = form.getForm().findField('saison');
+        if (!saisonField.isValid()) {
+            Ext.Msg.alert('Erreur', "Saison invalide (format attendu : AAAA-AAAA, ex : 2025-2026).");
+            return;
+        }
+        var values = form.getForm().getValues();
+        delete values.apercu;
+        var htmlForm = document.createElement('form');
+        htmlForm.method = 'POST';
+        htmlForm.action = '/bilanPdf.php';
+        htmlForm.target = '_blank';
+        Ext.Object.each(values, function (key, value) {
+            var input = document.createElement('input');
+            input.type = 'hidden';
+            input.name = key;
+            input.value = (value == null) ? '' : value;
+            htmlForm.appendChild(input);
+        });
+        document.body.appendChild(htmlForm);
+        htmlForm.submit();
+        document.body.removeChild(htmlForm);
     },
     addToolbarHallOfFame: function (grid) {
         grid.addDocked({

--- a/js/view/bilan/Form.js
+++ b/js/view/bilan/Form.js
@@ -1,0 +1,141 @@
+Ext.define('Ufolep13Volley.view.bilan.Form', {
+    extend: 'Ext.form.Panel',
+    alias: 'widget.bilanform',
+    title: 'Bilan annuel',
+    closable: true,
+    bodyPadding: 15,
+    autoScroll: true,
+    scrollable: true,
+    defaults: {
+        anchor: '100%'
+    },
+    initComponent: function () {
+        var now = new Date();
+        var y = now.getFullYear();
+        var m = now.getMonth() + 1;
+        // annee de fin de la derniere saison terminee (une saison finit en juin)
+        var y2 = (m >= 7) ? y : y - 1;
+        var defaultSaison = (y2 - 1) + '-' + y2;
+
+        this.items = [
+            {
+                xtype: 'fieldset',
+                title: 'Saison',
+                items: [
+                    {
+                        xtype: 'fieldcontainer',
+                        layout: 'hbox',
+                        items: [
+                            {
+                                xtype: 'textfield',
+                                name: 'saison',
+                                fieldLabel: 'Saison',
+                                labelWidth: 60,
+                                width: 220,
+                                value: defaultSaison,
+                                regex: /^\d{4}-\d{4}$/,
+                                regexText: "Format attendu : AAAA-AAAA (ex : 2025-2026)",
+                                allowBlank: false
+                            },
+                            {
+                                xtype: 'button',
+                                text: 'Charger les chiffres',
+                                glyph: 'xf019@FontAwesome',
+                                margin: '0 0 0 10',
+                                action: 'loadBilanData'
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                xtype: 'fieldset',
+                title: 'Chiffres extraits de la base (lecture seule)',
+                items: [
+                    {
+                        xtype: 'displayfield',
+                        name: 'apercu',
+                        hideLabel: true,
+                        value: '<em>Cliquez sur « Charger les chiffres » pour extraire les données de la saison.</em>'
+                    }
+                ]
+            },
+            {
+                xtype: 'fieldset',
+                title: 'Commentaires à compléter',
+                defaults: {
+                    anchor: '100%',
+                    labelAlign: 'top'
+                },
+                items: [
+                    {
+                        xtype: 'textfield',
+                        name: 'responsable',
+                        fieldLabel: 'Responsable de la commission',
+                        labelAlign: 'left',
+                        labelWidth: 200,
+                        width: 500
+                    },
+                    {
+                        xtype: 'textarea',
+                        name: 'types_public',
+                        fieldLabel: 'Types de public participant',
+                        height: 60,
+                        value: "Adultes féminins et masculins\n"
+                            + "Jeunes (16 ans + avec accord parental géré par le club d'affiliation)"
+                    },
+                    {
+                        xtype: 'textarea',
+                        name: 'formations',
+                        fieldLabel: 'Formations effectuées',
+                        height: 45,
+                        value: 'Néant'
+                    },
+                    {
+                        xtype: 'textarea',
+                        name: 'reunions',
+                        fieldLabel: 'Réunions statutaires / participation',
+                        height: 60
+                    },
+                    {
+                        xtype: 'textarea',
+                        name: 'impression_generale',
+                        fieldLabel: 'Impression générale sur la saison / besoins',
+                        height: 100
+                    },
+                    {
+                        xtype: 'textarea',
+                        name: 'coupe_nationale',
+                        fieldLabel: 'Coupe nationale',
+                        height: 100
+                    },
+                    {
+                        xtype: 'textarea',
+                        name: 'axes_amelioration',
+                        fieldLabel: "Axes d'amélioration",
+                        height: 100
+                    }
+                ]
+            }
+        ];
+
+        this.dockedItems = [
+            {
+                xtype: 'toolbar',
+                dock: 'bottom',
+                items: [
+                    '->',
+                    {
+                        xtype: 'button',
+                        text: 'Télécharger le PDF',
+                        glyph: 'xf1c1@FontAwesome',
+                        scale: 'medium',
+                        action: 'downloadBilanPdf'
+                    }
+                ]
+            }
+        ];
+
+        this.callParent(arguments);
+    }
+});

--- a/rest/action.php
+++ b/rest/action.php
@@ -109,6 +109,10 @@ try {
             require_once __DIR__ . "/../classes/BlackListTeams.php";
             $manager = new BlackListTeams();
             break;
+        case 'bilan':
+            require_once __DIR__ . "/../classes/Bilan.php";
+            $manager = new Bilan();
+            break;
         case 'club':
             require_once __DIR__ . "/../classes/Club.php";
             $manager = new Club();

--- a/sql/bilan_annuel.sql
+++ b/sql/bilan_annuel.sql
@@ -1,0 +1,133 @@
+-- =============================================================================
+-- BILAN ANNUEL — moteur de donnees  (saison 2025-2026 : sept. 2025 -> juin 2026)
+-- =============================================================================
+-- Fournit tous les chiffres du "Bilan d'activites" officiel (cf. modele PDF).
+-- Fichier en lecture seule, a executer requete par requete.
+--
+-- POUR CHANGER DE SAISON, remplacer partout :
+--   * bornes de dates (matchs)   '2025-09-01' et '2026-06-30'
+--   * periode championnat         '2025-2026'          (requetes 4a / detail)
+--   * periode coupe               '2026'               (requete 4b)
+--       -> convention : periode de coupe = annee civile des finales (2e annee
+--          de la saison). Championnats en 'YYYY-YYYY+1'.
+--
+-- DEFINITIONS (choisies pour etre RECONSTRUCTIBLES sur une saison passee) :
+--   * "participant" = a joue au moins un match dans la saison.
+--     -> clubs et licencies sont derives des MATCHS (matches / match_player),
+--        pas des rosters (classements/joueur_equipe) qui sont un instantane de
+--        la saison courante uniquement.
+--   * Les matchs passes sont conserves en base (statut ARCHIVED, plus supprimes)
+--     -> le filtre saison se fait UNIQUEMENT par date, jamais par match_status.
+--   * Un match est "joue" s'il a un score saisi ou un forfait.
+--
+-- MAPPING format : 6x6 = Masculin + Coupe Isoardi ; 4x4 = Feminin + Mixte +
+--   Coupe Khoury Hanna. Coupes = phase de poule + phases finales regroupees
+--   (Isoardi = c + cf ; Khoury Hanna = kh + kf).
+-- =============================================================================
+
+
+-- -----------------------------------------------------------------------------
+-- 1) MATCHS JOUES PAR COMPETITION  (+ total)   [MANIFESTATIONS, MATCHS]
+--    Coupes regroupees poule + finales, libelles au format du bilan officiel.
+-- -----------------------------------------------------------------------------
+SELECT CASE code
+           WHEN 'm' THEN 'Championnat Masculin 6x6'
+           WHEN 'f' THEN 'Championnat Feminin 4x4'
+           WHEN 'mo' THEN 'Championnat Mixte 4x4'
+           WHEN 'c' THEN 'Coupe Departementale Isoardi 6x6'
+           WHEN 'kh' THEN 'Coupe Departementale Khoury Hanna 4x4'
+           ELSE '*** TOTAL ***' END AS competition,
+       COUNT(*)                     AS nb_matchs
+FROM (SELECT CASE
+                 WHEN m.code_competition = 'cf' THEN 'c'
+                 WHEN m.code_competition = 'kf' THEN 'kh'
+                 ELSE m.code_competition END AS code
+      FROM matchs_view m
+      WHERE STR_TO_DATE(m.date_reception, '%d/%m/%Y') BETWEEN '2025-09-01' AND '2026-06-30'
+        AND ((m.score_equipe_dom + m.score_equipe_ext) > 0 OR m.forfait_dom = 1 OR m.forfait_ext = 1)) x
+GROUP BY code WITH ROLLUP
+ORDER BY GROUPING(code), nb_matchs DESC;
+
+
+-- -----------------------------------------------------------------------------
+-- 2) NOMBRE DE CLUBS PARTICIPANT
+--    Clubs ayant au moins une equipe ayant joue un match de championnat.
+-- -----------------------------------------------------------------------------
+SELECT COUNT(DISTINCT e.id_club) AS nb_clubs_participants
+FROM matchs_view m
+         JOIN equipes e ON e.id_equipe IN (m.id_equipe_dom, m.id_equipe_ext)
+WHERE STR_TO_DATE(m.date_reception, '%d/%m/%Y') BETWEEN '2025-09-01' AND '2026-06-30'
+  AND m.code_competition IN ('m', 'f', 'mo');
+
+
+-- -----------------------------------------------------------------------------
+-- 3) NOMBRE DE LICENCIES PARTICIPANT
+--    Joueurs ayant figure sur au moins une feuille de match de la saison.
+-- -----------------------------------------------------------------------------
+SELECT COUNT(DISTINCT mp.id_player) AS nb_licencies_participants
+FROM match_player mp
+         JOIN matchs_view m ON m.id_match = mp.id_match
+WHERE STR_TO_DATE(m.date_reception, '%d/%m/%Y') BETWEEN '2025-09-01' AND '2026-06-30';
+
+
+-- -----------------------------------------------------------------------------
+-- 4a) EQUIPES RECOMPENSEES EN CHAMPIONNAT  (+ total)   [CHAMPIONNAT DEPT.]
+--     1er et 2e par division, a mi-saison ET en fin de saison (phase Dept.),
+--     pour les 3 championnats.
+-- -----------------------------------------------------------------------------
+SELECT IF(GROUPING(league) = 1, '*** TOTAL ***', league) AS championnat,
+       SUM(title LIKE 'Championne mi-saison%')            AS mi_saison_1er,
+       SUM(title LIKE 'Vice%mi-saison%')                  AS mi_saison_2e,
+       SUM(title LIKE 'Championne Dept.%')                AS fin_saison_1er,
+       SUM(title LIKE 'Vice%Dept.%')                      AS fin_saison_2e,
+       COUNT(*)                                           AS total_recompenses
+FROM hall_of_fame
+WHERE period = '2025-2026'
+GROUP BY league WITH ROLLUP
+ORDER BY GROUPING(league), total_recompenses DESC;
+
+
+-- -----------------------------------------------------------------------------
+-- 4b) COUPES DECERNEES (liste des vainqueurs ; le nb de coupes = nb de lignes)
+--     Inclut le Trophee du fair-play. Pour l'exclure : AND league LIKE 'Coupe%'.
+-- -----------------------------------------------------------------------------
+SELECT league AS recompense,
+       team_name AS vainqueur
+FROM hall_of_fame
+WHERE period = '2026'
+  AND title = 'Vainqueur'
+ORDER BY league;
+
+
+-- =============================================================================
+-- DETAILS COMPLEMENTAIRES (hors bilan officiel, par club) -- INSTANTANE saison
+-- courante uniquement (bases sur classements/joueur_equipe, non reconstructible
+-- une fois la saison remplacee).
+-- =============================================================================
+
+-- D1) Nombre d'equipes par championnat et par club  (+ total)
+SELECT IF(GROUPING(cl.id) = 1, '*** TOTAL ***', MAX(cl.nom))                   AS club,
+       COUNT(DISTINCT CASE WHEN c.code_competition = 'm' THEN c.id_equipe END)  AS eq_masculin,
+       COUNT(DISTINCT CASE WHEN c.code_competition = 'f' THEN c.id_equipe END)  AS eq_feminin,
+       COUNT(DISTINCT CASE WHEN c.code_competition = 'mo' THEN c.id_equipe END) AS eq_mixte,
+       COUNT(DISTINCT c.id_equipe)                                              AS total_equipes
+FROM classements c
+         JOIN equipes e ON e.id_equipe = c.id_equipe
+         JOIN clubs cl ON cl.id = e.id_club
+WHERE c.code_competition IN ('m', 'f', 'mo')
+GROUP BY cl.id WITH ROLLUP
+ORDER BY GROUPING(cl.id), total_equipes DESC;
+
+-- D2) Nombre de licencies (inscrits sur roster) M/F par club  (+ total)
+SELECT IF(GROUPING(cl.id) = 1, '*** TOTAL ***', MAX(cl.nom)) AS club,
+       COUNT(DISTINCT CASE WHEN j.sexe = 'M' THEN j.id END)  AS licencies_h,
+       COUNT(DISTINCT CASE WHEN j.sexe = 'F' THEN j.id END)  AS licencies_f,
+       COUNT(DISTINCT j.id)                                  AS total_licencies
+FROM joueurs j
+         JOIN clubs cl ON cl.id = j.id_club
+WHERE EXISTS (SELECT 1
+              FROM joueur_equipe je
+                       JOIN classements c ON c.id_equipe = je.id_equipe
+              WHERE je.id_joueur = j.id)
+GROUP BY cl.id WITH ROLLUP
+ORDER BY GROUPING(cl.id), total_licencies DESC;


### PR DESCRIPTION
## Objectif

Permettre de générer le **bilan d'activités annuel** (PDF officiel) directement depuis l'administration, avec les chiffres pré-remplis depuis la base.

## Fonctionnement

Nouveau point de menu **« Bilan annuel »** dans `admin.php` :
1. On saisit la saison (ex. `2025-2026`, pré-remplie par défaut sur la dernière saison terminée).
2. « Charger les chiffres » extrait de la base : matchs par compétition (+ total), clubs et licenciés participants, équipes récompensées, coupes décernées.
3. On complète les commentaires libres (réunions, impression générale, coupe nationale, axes d'amélioration…).
4. « Télécharger le PDF » génère le bilan au format officiel.

## Choix techniques

- **Définitions reconstructibles** : « participant » = a joué au moins un match (`matches`/`match_player`), filtre saison **par date** (jamais par `match_status`, puisque les matchs passés sont conservés en `ARCHIVED`). Les bilans de saisons passées restent donc générables.
- **PDF** : FPDF (déjà utilisé par `teamSheetPdf.php`). Les chiffres sont **recalculés côté serveur** dans `bilanPdf.php` (non falsifiables) ; endpoint réservé aux admins.
- Conventions de période `hall_of_fame` : championnats en `AAAA-AAAA+1`, coupes en année civile des finales (2e année de saison).

## Fichiers

- `classes/Bilan.php` — extraction des chiffres
- `bilanPdf.php` — génération FPDF
- `rest/action.php` — route `/bilan`
- `js/administration.js`, `js/controller/Administration.js`, `js/view/bilan/Form.js` — UI admin
- `sql/bilan_annuel.sql` — requêtes de référence

## Validation

Chiffres 2025-2026 vérifiés en base : 939 matchs, 35 clubs, 1133 licenciés, 74 équipes récompensées, 3 coupes. Testé manuellement (formulaire + téléchargement PDF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
