### PR TITLE
feat: photos de la page Facebook sur la page d'accueil (remplace Flickr)

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -14,5 +14,7 @@ MAIL_SMTPSECURE=<protocol for smtp secure, e.g. 'ssl'>
 MAIL_PORT=<port for smtp, e.g. 465>
 COVID_MODE=<true to enable unlimited reports, false for 1 report max>
 FLICKR_API_KEY=<your flickr api key if you have one (for public images display). leave blank if not needed>
+FACEBOOK_PAGE_ID=<your facebook page id (for public images display from the page). leave blank if not needed>
+FACEBOOK_PAGE_TOKEN=<never-expiring facebook page access token. leave blank to fall back on flickr>
 PROXY_URL=<your proxy url, if any. it is used for Unirest requests, leave blank if not needed>
 SEEDING_TOURNAMENT_WEEK=<text to describe which week will host the seeding tournament, e.g. "semaine du 14 au 18 octobre 2024". leave blank if not needed>

--- a/ajax/getVolleyballImages.php
+++ b/ajax/getVolleyballImages.php
@@ -2,27 +2,106 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../classes/Configuration.php';
 $configuration = new Configuration();
-$flickr_api_key = $configuration->flickr_api_key;
-if (empty($flickr_api_key)) {
-    echo json_encode(array());
-    exit(0);
-}
-$proxy_url = $configuration->proxy_url;
 Unirest\Request::verifyPeer(false);
+$proxy_url = $configuration->proxy_url;
 if (!empty($proxy_url)) {
     Unirest\Request::proxy($proxy_url, 3128, CURLPROXY_HTTP);
 }
 $headers = array('Accept' => 'application/json');
-$query = array(
-    'method' => 'flickr.photos.search',
-    'sort' => 'date-posted-desc',
-    'per_page' => '30',
-    'api_key' => $flickr_api_key,
-    'text' => 'ufolep volley',
-    'orientation' => 'landscape',
-    'format' => 'json',
-    'nojsoncallback' => 1,
-);
-$response = Unirest\Request::get('https://api.flickr.com/services/rest', $headers, $query);
-$test = json_decode($response->raw_body);
-echo json_encode($test->photos);
+
+function get_facebook_photos(Configuration $configuration, array $headers): ?array
+{
+    if (empty($configuration->facebook_page_id) || empty($configuration->facebook_page_token)) {
+        return null;
+    }
+    $query = array(
+        'type' => 'uploaded',
+        'fields' => 'images',
+        'limit' => '30',
+        'access_token' => $configuration->facebook_page_token,
+    );
+    $url = sprintf('https://graph.facebook.com/v21.0/%s/photos', $configuration->facebook_page_id);
+    $response = Unirest\Request::get($url, $headers, $query);
+    if ($response->code !== 200) {
+        return null;
+    }
+    $body = json_decode($response->raw_body);
+    if (empty($body->data)) {
+        return null;
+    }
+    $photos = array();
+    foreach ($body->data as $photo) {
+        if (empty($photo->images)) {
+            continue;
+        }
+        // images est trié de la plus grande à la plus petite : prendre la première <= 1280px de large
+        $src = end($photo->images)->source;
+        foreach ($photo->images as $image) {
+            if ($image->width <= 1280) {
+                $src = $image->source;
+                break;
+            }
+        }
+        $photos[] = array('id' => $photo->id, 'src' => $src);
+    }
+    if (empty($photos)) {
+        return null;
+    }
+    return array(
+        'source' => 'facebook',
+        'more_link' => 'https://www.facebook.com/ufolep13volley/',
+        'photos' => $photos,
+    );
+}
+
+function get_flickr_photos(Configuration $configuration, array $headers): ?array
+{
+    if (empty($configuration->flickr_api_key)) {
+        return null;
+    }
+    $query = array(
+        'method' => 'flickr.photos.search',
+        'sort' => 'date-posted-desc',
+        'per_page' => '30',
+        'api_key' => $configuration->flickr_api_key,
+        'text' => 'ufolep volley',
+        'orientation' => 'landscape',
+        'format' => 'json',
+        'nojsoncallback' => 1,
+    );
+    $response = Unirest\Request::get('https://api.flickr.com/services/rest', $headers, $query);
+    if ($response->code !== 200) {
+        return null;
+    }
+    $body = json_decode($response->raw_body);
+    if (empty($body->photos->photo)) {
+        return null;
+    }
+    $photos = array();
+    foreach ($body->photos->photo as $photo) {
+        $photos[] = array(
+            'id' => $photo->id,
+            'src' => sprintf('https://farm%s.staticflickr.com/%s/%s_%s.jpg',
+                $photo->farm, $photo->server, $photo->id, $photo->secret),
+        );
+    }
+    return array(
+        'source' => 'flickr',
+        'more_link' => 'https://www.flickr.com/photos/149988821@N04/albums/',
+        'photos' => $photos,
+    );
+}
+
+try {
+    $result = get_facebook_photos($configuration, $headers);
+    if ($result === null) {
+        $result = get_flickr_photos($configuration, $headers);
+    }
+} catch (Exception $e) {
+    $result = null;
+}
+if ($result === null) {
+    $result = array('source' => '', 'more_link' => '', 'photos' => array());
+}
+header('Content-Type: application/json');
+echo json_encode($result);

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -15,6 +15,8 @@ class Configuration
     public bool $covid_mode;
     public string $proxy_url;
     public string $flickr_api_key;
+    public string $facebook_page_id;
+    public string $facebook_page_token;
     public string $seeding_tournament_week;
 
     /**
@@ -44,6 +46,8 @@ class Configuration
         $this->mail_port = (int)($_ENV['MAIL_PORT'] ?? 25);
         $this->covid_mode = ($_ENV['COVID_MODE'] ?? 'false') === 'true';
         $this->flickr_api_key = $_ENV['FLICKR_API_KEY'] ?? '';
+        $this->facebook_page_id = $_ENV['FACEBOOK_PAGE_ID'] ?? '';
+        $this->facebook_page_token = $_ENV['FACEBOOK_PAGE_TOKEN'] ?? '';
         $this->proxy_url = $_ENV['PROXY_URL'] ?? '';
         $this->seeding_tournament_week = $_ENV['SEEDING_TOURNAMENT_WEEK'] ?? '';
     }

--- a/pages/components/carousel/Photos.js
+++ b/pages/components/carousel/Photos.js
@@ -1,21 +1,54 @@
 export default {
     template: `
-      <div class="flex flex-col items-center">
-        <div class="carousel carousel-vertical rounded-box h-96">
-          <div v-for="item in items.photo" :key="item.id" class="carousel-item h-full">
-            <img
-                :src="'https://farm'+item.farm+'.staticflickr.com/'+item.server+'/'+item.id+'_'+item.secret+'.jpg'"/>
+      <div v-if="items.photos.length" class="flex flex-col items-center gap-2 w-full max-w-5xl">
+        <div class="relative w-full">
+          <div ref="track"
+               class="flex gap-2 overflow-x-auto snap-x snap-mandatory scroll-smooth rounded-box"
+               style="scrollbar-width: none">
+            <div v-for="(item, index) in items.photos" :key="item.id"
+                 class="snap-start shrink-0 w-full sm:w-[calc((100%-0.5rem)/2)] lg:w-[calc((100%-1rem)/3)] cursor-zoom-in"
+                 @click="openLightbox(index)">
+              <img :src="item.src" loading="lazy"
+                   class="h-56 w-full object-cover rounded-box hover:opacity-80 transition-opacity"/>
+            </div>
           </div>
+          <button class="btn btn-circle btn-sm absolute left-2 top-1/2 -translate-y-1/2 shadow"
+                  aria-label="Photos précédentes"
+                  @click="scroll(-1)">❮
+          </button>
+          <button class="btn btn-circle btn-sm absolute right-2 top-1/2 -translate-y-1/2 shadow"
+                  aria-label="Photos suivantes"
+                  @click="scroll(1)">❯
+          </button>
         </div>
-        <div>
+        <div v-if="items.more_link">
           d'autres photos dispos <a class="link" target="_blank"
-                                    href="https://www.flickr.com/photos/149988821@N04/albums/">ici</a> !
+                                    :href="items.more_link">ici</a> !
+        </div>
+        <div v-if="lightboxIndex !== null"
+             class="fixed inset-0 z-50 bg-black/80 flex items-center justify-center p-4"
+             @click.self="closeLightbox">
+          <img :src="items.photos[lightboxIndex].src"
+               class="max-h-full max-w-full rounded-box shadow-lg"/>
+          <button class="btn btn-circle absolute left-4 top-1/2 -translate-y-1/2"
+                  aria-label="Photo précédente"
+                  @click="moveLightbox(-1)">❮
+          </button>
+          <button class="btn btn-circle absolute right-4 top-1/2 -translate-y-1/2"
+                  aria-label="Photo suivante"
+                  @click="moveLightbox(1)">❯
+          </button>
+          <button class="btn btn-circle absolute right-4 top-4"
+                  aria-label="Fermer"
+                  @click="closeLightbox">✕
+          </button>
         </div>
       </div>
     `,
     data() {
         return {
-            items: [],
+            items: {photos: [], more_link: ''},
+            lightboxIndex: null,
             fetchUrl: "/ajax/getVolleyballImages.php"
         };
     },
@@ -30,8 +63,34 @@ export default {
                     console.error("Erreur lors du chargement:", error);
                 });
         },
+        scroll(direction) {
+            const track = this.$refs.track;
+            track.scrollBy({left: direction * track.clientWidth, behavior: 'smooth'});
+        },
+        openLightbox(index) {
+            this.lightboxIndex = index;
+        },
+        closeLightbox() {
+            this.lightboxIndex = null;
+        },
+        moveLightbox(direction) {
+            const count = this.items.photos.length;
+            this.lightboxIndex = (this.lightboxIndex + direction + count) % count;
+        },
+        onKeydown(event) {
+            if (this.lightboxIndex === null) return;
+            if (event.key === 'Escape') this.closeLightbox();
+            if (event.key === 'ArrowLeft') this.moveLightbox(-1);
+            if (event.key === 'ArrowRight') this.moveLightbox(1);
+        },
     },
     created() {
         this.fetch();
+    },
+    mounted() {
+        document.addEventListener('keydown', this.onKeydown);
+    },
+    unmounted() {
+        document.removeEventListener('keydown', this.onKeydown);
     },
 };


### PR DESCRIPTION
## Objectif

Afficher sur la page d'accueil les photos de la page Facebook du comité (https://www.facebook.com/ufolep13volley/) à la place des photos Flickr, et moderniser le carousel.

## Changements

### Backend — `ajax/getVolleyballImages.php`
- Appelle l'API Graph Facebook (`/{page-id}/photos?type=uploaded`) avec le token de Page
- **Repli automatique sur Flickr** si `FACEBOOK_PAGE_TOKEN` est absent ou si l'appel Facebook échoue (token invalidé, indisponibilité Meta)
- Sortie normalisée quel que soit le fournisseur : `{source, more_link, photos: [{id, src}]}`
- Pour chaque photo Facebook, sélection de la plus grande version ≤ 1280px de large

### Frontend — `pages/components/carousel/Photos.js`
- Remplacement du carousel vertical une-photo-à-la-fois par une galerie horizontale : 3 photos visibles sur desktop, 2 sur tablette, 1 sur mobile
- Flèches de navigation (défilement par page), scroll-snap, défilement tactile
- Lightbox au clic : plein écran, navigation ← / → / Échap, bouclage
- Images en `loading="lazy"`
- Le composant se masque entièrement si aucune photo n'est disponible

### Configuration
- `FACEBOOK_PAGE_ID` et `FACEBOOK_PAGE_TOKEN` (optionnels) dans `Configuration.php` et `.env-template`

## Déploiement

⚠️ Renseigner `FACEBOOK_PAGE_ID` et `FACEBOOK_PAGE_TOKEN` dans le `.env` de production avant/pendant le déploiement — sinon le site retombe silencieusement sur Flickr (comportement voulu).

Le token de Page n'expire pas, mais serait invalidé par un changement de mot de passe du compte Facebook admin (il faudrait alors le régénérer via l'Explorateur Graph API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
