### PR TITLE
Fix #247: Un email = un compte — fusion des doublons et connexion par login ou email

### DIFF
--- a/classes/UserManager.php
+++ b/classes/UserManager.php
@@ -121,14 +121,15 @@ class UserManager extends Generic
     public function create_or_update_leader_account($email, $team_id): void
     {
         $login = strtolower($email);
-        // create leader user account if it does not exist
+        // recherche par email : un email = un compte (issue #247), même si le
+        // compte existant porte un login historique différent de l'email
         $bindings = array();
         $bindings[] = array('type' => 's', 'value' => $login);
-        $user = $this->get_one("login = ?", $bindings);
+        $user = $this->get_one("email = ?", $bindings);
         if (!$user) {
             $password = Generic::randomPassword();
             $this->insert_user($login, $email, $password);
-            $user = $this->get_one("login = ?", $bindings);
+            $user = $this->get_one("email = ?", $bindings);
             $this->email->sendMailNewUser($email, $login, $password);
             $this->activity->add("Compte $login créé");
             error_log("le compte $login n'existe pas, création ok");
@@ -199,6 +200,17 @@ class UserManager extends Generic
     }
 
     /**
+     * @throws Exception
+     */
+    public function isEmailExists($email): bool
+    {
+        $sql = "SELECT COUNT(*) AS cnt FROM comptes_acces WHERE email = ?";
+        $bindings = array(array('type' => 's', 'value' => $email));
+        $results = $this->sql_manager->execute($sql, $bindings);
+        return intval($results[0]['cnt']) > 0;
+    }
+
+    /**
      * @param $login
      * @param $email
      * @param $id_equipe
@@ -208,6 +220,10 @@ class UserManager extends Generic
     {
         if ($this->isUserExists($login)) {
             throw new Exception("Ce compte existe déjà !");
+        }
+        // un email = un compte (issue #247)
+        if ($this->isEmailExists($email)) {
+            throw new Exception("Un compte existe déjà avec cet email !");
         }
         $password = Generic::randomPassword();
         $user_id = $this->insert_user($login, $email, $password);
@@ -252,6 +268,10 @@ class UserManager extends Generic
         $email,
         $dirtyFields = null)
     {
+        // un email = un compte (issue #247) : le login des nouveaux comptes est l'email
+        if (empty($id) && empty($login)) {
+            $login = strtolower($email);
+        }
         $bindings = array();
         $inputs = array(
             'id' => $id,
@@ -260,7 +280,11 @@ class UserManager extends Generic
         );
         if (empty($id)) {
             if ($this->isUserExists($login)) {
-                throw new Exception("L'utilisateur n'existe pas !");
+                throw new Exception("Ce login existe déjà !");
+            }
+            // un email = un compte (issue #247)
+            if ($this->isEmailExists($email)) {
+                throw new Exception("Un compte existe déjà avec cet email !");
             }
         }
         if (empty($id)) {
@@ -380,6 +404,35 @@ class UserManager extends Generic
     }
 
     /**
+     * Authentifie un compte par login OU email (issue #247). Le sel du hash
+     * reste le login stocké : aucun mot de passe n'est invalidé.
+     * @return array|null id_user, login, is_admin, id_equipe (première équipe liée)
+     * @throws Exception
+     */
+    public function authenticate(string $login_or_email, string $password): ?array
+    {
+        $sql = "SELECT  ut.team_id AS id_equipe,
+                        ca.login,
+                        ca.id AS id_user,
+                        ca.is_admin
+                FROM comptes_acces ca
+                LEFT JOIN users_teams ut ON ca.id = ut.user_id
+                WHERE (ca.login = ? OR ca.email = ?)
+                AND ca.password_hash = MD5(CONCAT(CONVERT(ca.login USING utf8mb4), ?))
+                LIMIT 1";
+        $bindings = array(
+            array('type' => 's', 'value' => $login_or_email),
+            array('type' => 's', 'value' => $login_or_email),
+            array('type' => 's', 'value' => $password),
+        );
+        $results = $this->sql_manager->execute($sql, $bindings);
+        if (count($results) === 0) {
+            return null;
+        }
+        return $results[0];
+    }
+
+    /**
      * @throws Exception
      */
     public function login(): void
@@ -394,37 +447,14 @@ class UserManager extends Generic
             ));
             return;
         }
-        $sql = "SELECT  ut.team_id AS id_equipe,
-                        ca.login,
-                        ca.id AS id_user,
-                        ca.is_admin
-                FROM comptes_acces ca
-                LEFT JOIN users_teams ut ON ca.id = ut.user_id
-                WHERE ca.login = ?
-                AND ca.password_hash = MD5(CONCAT(?, ?))
-                LIMIT 1";
-        $bindings = array();
-        $bindings[] = array(
-            'type' => 's',
-            'value' => $login
-        );
-        $bindings[] = array(
-            'type' => 's',
-            'value' => $login
-        );
-        $bindings[] = array(
-            'type' => 's',
-            'value' => $password
-        );
-        $results = $this->sql_manager->execute($sql, $bindings);
-        if (count($results) != 1) {
+        $data = $this->authenticate($login, $password);
+        if ($data === null) {
             echo json_encode(array(
                 'success' => false,
                 'message' => 'Login ou mot de passe incorrect'
             ));
             return;
         }
-        $data = $results[0];
         $this->setSessionRoles((int)$data['id_user'], $data['login'], !empty($data['is_admin']), $data['id_equipe']);
         if (!empty($redirect)) {
             header('Location: ' . urldecode($redirect));
@@ -475,15 +505,18 @@ class UserManager extends Generic
     }
 
     /**
+     * Demande de réinitialisation par email seul : un email = un compte
+     * (issue #247). Le paramètre $login est conservé pour compatibilité.
      * @throws Exception
      */
-    public function request_reset_password($login,
-                                           $user_email,
+    public function request_reset_password($user_email,
+                                           $login = null,
                                            $dirtyFields = null): void
     {
-        $results = $this->get("login = '$login' AND email = '$user_email'");
+        $bindings = array(array('type' => 's', 'value' => $user_email));
+        $results = $this->get("email = ?", $bindings);
         if (count($results) === 0) {
-            throw new Exception("Il n'existe pas de compte avec cette adresse email et ce login !");
+            throw new Exception("Il n'existe pas de compte avec cette adresse email !");
         }
         $result = $results[0];
         $url = $this->get_page_url() .

--- a/js/view/form/reset_password.js
+++ b/js/view/form/reset_password.js
@@ -12,11 +12,6 @@ Ext.define('Ufolep13Volley.view.form.reset_password', {
     autoScroll: true,
     items: [
         {
-            name: 'login',
-            fieldLabel: "Login",
-            allowBlank: false,
-        },
-        {
             name: 'user_email',
             fieldLabel: "Email",
             allowBlank: false,

--- a/js/view/user/Edit.js
+++ b/js/view/user/Edit.js
@@ -27,8 +27,9 @@ Ext.define('Ufolep13Volley.view.user.Edit', {
             {
                 name: 'login',
                 fieldLabel: 'Login',
-                allowBlank: false,
+                allowBlank: true,
                 readOnly: true,
+                emptyText: '(rempli automatiquement avec l\'email)',
                 msgTarget: 'under'
             },
             {

--- a/pages/components/form/Login.js
+++ b/pages/components/form/Login.js
@@ -16,7 +16,7 @@ export default {
 
           <div class="form-control">
             <label class="label">
-              <span class="label-text">Nom d'utilisateur</span>
+              <span class="label-text">Login ou email</span>
             </label>
             <input name="login" type="text" class="input input-bordered" required/>
           </div>

--- a/sql/get_user_teams.sql
+++ b/sql/get_user_teams.sql
@@ -1,6 +1,4 @@
 SELECT DISTINCT t.*
-FROM comptes_acces u
-         JOIN comptes_acces ca ON ca.email = u.email
-         JOIN users_teams ut on ca.id = ut.user_id
+FROM users_teams ut
          JOIN teams_view t on ut.team_id = t.id_equipe
-WHERE u.id = ?
+WHERE ut.user_id = ?

--- a/unit_tests/AuthenticationTest.php
+++ b/unit_tests/AuthenticationTest.php
@@ -1,0 +1,109 @@
+<?php
+require_once __DIR__ . '/../classes/UserManager.php';
+require_once __DIR__ . '/../classes/SqlManager.php';
+require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/UfolepTestCase.php';
+
+/**
+ * Issue #247 — un email = un compte.
+ *
+ * La connexion accepte le login historique OU l'email ; le sel du hash de
+ * mot de passe reste le login stocké (aucun mot de passe invalidé).
+ * La création de compte refuse un email déjà utilisé et recycle le compte
+ * existant quand on rattache un responsable par email.
+ */
+class AuthenticationTest extends UfolepTestCase
+{
+    private const TEST_LOGIN = 'auth_test_login';
+    private const TEST_EMAIL = 'auth_test@ufolep.test';
+    private const TEST_PASSWORD = 'secret_pwd';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->delete_test_data();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->delete_test_data();
+        parent::tearDown();
+    }
+
+    private function delete_test_data(): void
+    {
+        $this->sql->execute("DELETE FROM users_teams WHERE user_id IN (SELECT id FROM comptes_acces WHERE email = '" . self::TEST_EMAIL . "')");
+        $this->sql->execute("DELETE FROM comptes_acces WHERE email = '" . self::TEST_EMAIL . "'");
+    }
+
+    /**
+     * Compte historique : login différent de l'email, hash salé par le login.
+     */
+    private function create_account(): int
+    {
+        return (int)$this->sql->execute(
+            "INSERT INTO comptes_acces SET
+                login = '" . self::TEST_LOGIN . "',
+                email = '" . self::TEST_EMAIL . "',
+                password_hash = MD5(CONCAT('" . self::TEST_LOGIN . "', '" . self::TEST_PASSWORD . "'))");
+    }
+
+    public function test_authenticate_with_historical_login()
+    {
+        $userId = $this->create_account();
+        $account = (new UserManager())->authenticate(self::TEST_LOGIN, self::TEST_PASSWORD);
+        $this->assertNotNull($account);
+        $this->assertEquals($userId, (int)$account['id_user']);
+    }
+
+    public function test_authenticate_with_email_uses_stored_login_as_salt()
+    {
+        $userId = $this->create_account();
+        // connexion par email : le mot de passe reste valide car le sel est le login stocké
+        $account = (new UserManager())->authenticate(self::TEST_EMAIL, self::TEST_PASSWORD);
+        $this->assertNotNull($account);
+        $this->assertEquals($userId, (int)$account['id_user']);
+        $this->assertEquals(self::TEST_LOGIN, $account['login']);
+    }
+
+    public function test_authenticate_with_wrong_password_returns_null()
+    {
+        $this->create_account();
+        $this->assertNull((new UserManager())->authenticate(self::TEST_LOGIN, 'mauvais_mdp'));
+        $this->assertNull((new UserManager())->authenticate(self::TEST_EMAIL, 'mauvais_mdp'));
+    }
+
+    public function test_authenticate_unknown_account_returns_null()
+    {
+        $this->assertNull((new UserManager())->authenticate('compte_inexistant', 'x'));
+    }
+
+    public function test_create_leader_account_reuses_existing_account_with_same_email()
+    {
+        $teamRow = $this->sql->execute("SELECT id_equipe FROM equipes LIMIT 1");
+        if (count($teamRow) === 0) {
+            $this->markTestSkipped("Aucune équipe disponible");
+        }
+        $teamId = (int)$teamRow[0]['id_equipe'];
+        $userId = $this->create_account();
+        $this->connect_as_admin();
+
+        // le compte existe avec un login historique différent de l'email :
+        // le rattachement par email doit recycler ce compte, pas en créer un autre
+        (new UserManager())->create_or_update_leader_account(self::TEST_EMAIL, $teamId);
+
+        $accounts = $this->sql->execute("SELECT id FROM comptes_acces WHERE email = '" . self::TEST_EMAIL . "'");
+        $this->assertCount(1, $accounts, "Aucun compte doublon ne doit être créé");
+        $this->assertEquals($userId, (int)$accounts[0]['id']);
+        $teamIds = (new UserManager())->getUserTeamIds($userId);
+        $this->assertContains($teamId, array_map('intval', $teamIds));
+    }
+
+    public function test_saveUser_refuses_creation_with_existing_email()
+    {
+        $this->create_account();
+        $this->connect_as_admin();
+        $this->expectException(Exception::class);
+        (new UserManager())->saveUser(null, 'autre_login', self::TEST_EMAIL);
+    }
+}


### PR DESCRIPTION
## Description
Résout #247 — un email = un compte. Fusion des comptes en doublon d'email (héritage du modèle à profil exclusif) et connexion par login **ou** email, sans invalider aucun mot de passe.

## Changements

**Backend**
- `UserManager::authenticate($login_or_email, $password)` : nouvelle méthode utilisée par `login()` — recherche par login OU email, le sel du hash reste le **login stocké** (`MD5(CONCAT(CONVERT(ca.login USING utf8mb4), ?))`, le `CONVERT` évite le mix de collations latin1/utf8 et reproduit les octets de l'ancien calcul)
- `create_or_update_leader_account` : recherche par **email** — recycle un compte existant à login historique au lieu de créer un doublon (indispensable avec `UNIQUE(email)`)
- `saveUser` / `createUser` : refus de création si l'email existe déjà ; `login = email` pour les nouveaux comptes
- `request_reset_password` : par email seul
- `sql/get_user_teams.sql` : suppression du hack d'aliasing par email (rendu inutile par la fusion)

**Frontend**
- Formulaire de connexion : libellé « Login ou email »
- Mot de passe oublié : email seul
- Création de compte admin (ExtJS) : login rempli automatiquement avec l'email

**Migration** (`ufolep13volley_python/sql/updates/2026/009-merge_duplicate_email_accounts.sql`) — générique, pas de valeurs en dur :
- Pour chaque email en doublon : conserve le compte `login = email`, lui transfère `users_teams`/`users_clubs`/`activity`/`survey` et le rôle admin, supprime le doublon
- Pose `UNIQUE KEY uq_email (email)`
- Concerne 4 paires : benallemand, isa_admin, ludo_admin, cyril_admin

## Tests
- [x] Nouveau `unit_tests/AuthenticationTest.php` (6 tests) : connexion par login historique, par email (sel = login stocké), mauvais mot de passe, compte inconnu, recyclage de compte par email, refus de doublon d'email — **6/6 OK**
- [x] Régression : `RolesTest` 9/9, `ActAsTest` 9/9, `ClubLeaderTest` 13/13
- [x] `php -l`, `npm run build` OK

## Points d'attention au déploiement
- **Jouer la migration 009 avant le déploiement** (locale ET OVH) : sans elle, la suppression de l'aliasing email prive les 4 comptes admin historiques de leurs équipes aliasées, et la connexion par email peut matcher un doublon arbitraire
- Les 4 personnes concernées utiliseront le login/mot de passe de leur compte « email » (les identifiants `*_admin` disparaissent) — les prévenir

🤖 Generated with [Claude Code](https://claude.com/claude-code)
