### PR TITLE
Fix #251: les fonctions « mon équipe » acceptent les admins aussi responsables d'équipe

### DIFF
--- a/classes/MatchMgr.php
+++ b/classes/MatchMgr.php
@@ -1666,9 +1666,8 @@ class MatchMgr extends Generic
      */
     public function acceptReport($code_match)
     {
-        if (UserManager::isAdmin()) {
-            throw new Exception("Un administrateur ne peut pas accepter un report !");
-        }
+        // un report s'accepte au nom d'une équipe : il faut le rôle
+        // responsable d'équipe (cumulable avec admin — issue #251)
         if (!UserManager::isTeamLeader()) {
             throw new Exception("Seul un responsable d'équipe peut accepter un report !");
         }

--- a/classes/Players.php
+++ b/classes/Players.php
@@ -97,9 +97,8 @@ class Players extends Generic
     public function getMyPlayers()
     {
         @session_start();
-        if (UserManager::isAdmin()) {
-            throw new Exception("Un administrateur ne peut pas faire ça !");
-        }
+        // les rôles se cumulent (issue #251) : seul compte le rôle
+        // responsable d'équipe, qu'il soit admin ou non
         if (!UserManager::isTeamLeader()) {
             throw new Exception("Seul un responsable d'équipe peut faire ça !");
         }
@@ -462,9 +461,6 @@ class Players extends Generic
      */
     function removePlayerFromMyTeam($idPlayer)
     {
-        if (UserManager::isAdmin()) {
-            throw new Exception("Un profil admin ne peut pas faire cette action !");
-        }
         if (!UserManager::isTeamLeader()) {
             throw new Exception("Seul un profil responsable d'équipe peut faire cette action !");
         }

--- a/classes/Team.php
+++ b/classes/Team.php
@@ -492,9 +492,6 @@ class Team extends Generic
 
     public function getMyTeam()
     {
-        if (UserManager::isAdmin()) {
-            throw new Exception("Un administrateur ne peut pas faire ça !");
-        }
         if (!UserManager::isTeamLeader()) {
             throw new Exception("Seul un responsable d'équipe peut faire ça !");
         }

--- a/classes/TimeSlot.php
+++ b/classes/TimeSlot.php
@@ -44,9 +44,6 @@ class TimeSlot extends Generic
     public function get_my_timeslots()
     {
         @session_start();
-        if (UserManager::isAdmin()) {
-            throw new Exception("Un administrateur ne peut pas faire ça !");
-        }
         if (!UserManager::isTeamLeader()) {
             throw new Exception("Seul un responsable d'équipe peut faire ça !");
         }

--- a/unit_tests/RolesTest.php
+++ b/unit_tests/RolesTest.php
@@ -1,5 +1,8 @@
 <?php
 require_once __DIR__ . '/../classes/UserManager.php';
+require_once __DIR__ . '/../classes/Players.php';
+require_once __DIR__ . '/../classes/TimeSlot.php';
+require_once __DIR__ . '/../classes/Team.php';
 require_once __DIR__ . '/../classes/SqlManager.php';
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/UfolepTestCase.php';
@@ -106,6 +109,61 @@ class RolesTest extends UfolepTestCase
         $this->assertTrue(UserManager::isTeamLeader());
         $this->assertTrue(UserManager::isClubLeader());
         $this->assertEquals((int)$teamRow[0]['id_club'], $_SESSION['id_club']);
+    }
+
+    /**
+     * Issue #251 — un admin AUSSI responsable d'équipe doit pouvoir utiliser
+     * les fonctions « mon équipe » (les anciens refus « un administrateur ne
+     * peut pas faire ça » datent du modèle à profil exclusif).
+     */
+    private function connect_as_admin_and_team_leader(): int
+    {
+        $teamRow = $this->sql->execute(
+            "SELECT id_equipe FROM equipes WHERE id_club IS NOT NULL LIMIT 1");
+        if (count($teamRow) === 0) {
+            $this->markTestSkipped("Aucune équipe disponible");
+        }
+        $id_equipe = (int)$teamRow[0]['id_equipe'];
+        $this->connect_as_team_leader($id_equipe);
+        $_SESSION['is_admin'] = true;
+        return $id_equipe;
+    }
+
+    public function test_admin_team_leader_can_get_my_players()
+    {
+        $this->connect_as_admin_and_team_leader();
+        $players = (new Players())->getMyPlayers();
+        $this->assertIsArray($players);
+    }
+
+    public function test_admin_team_leader_can_get_my_timeslots()
+    {
+        $this->connect_as_admin_and_team_leader();
+        $timeslots = (new TimeSlot())->get_my_timeslots();
+        $this->assertIsArray($timeslots);
+    }
+
+    public function test_admin_team_leader_can_get_my_team()
+    {
+        $this->connect_as_admin_and_team_leader();
+        $team = (new Team())->getMyTeam();
+        $this->assertNotEmpty($team);
+    }
+
+    public function test_admin_team_leader_passes_remove_player_guard()
+    {
+        $this->connect_as_admin_and_team_leader();
+        // joueur inexistant : on doit dépasser la garde de rôle et échouer
+        // sur l'appartenance à l'équipe, pas sur « un admin ne peut pas »
+        $this->expectExceptionMessage("Ce joueur n'est pas dans l'équipe !");
+        (new Players())->removePlayerFromMyTeam(-1);
+    }
+
+    public function test_pure_admin_still_refused_on_team_functions()
+    {
+        $this->connect_as_admin();
+        $this->expectExceptionMessage("Seul un responsable d'équipe peut faire ça !");
+        (new Players())->getMyPlayers();
     }
 
     public function test_setAdmin_grants_and_revokes()


### PR DESCRIPTION
## Description
Résout #251 — constaté en prod : `getMyPlayers` refusait un compte **admin + responsable d'équipe** avec « Un administrateur ne peut pas faire ça ! ». Ces gardes dataient du modèle à profil exclusif (#245 a rendu les rôles cumulables).

## Changements
Suppression du refus `isAdmin()` dans les 5 méthodes recensées (balayage complet) :
- `Players::getMyPlayers` (le cas remonté)
- `Players::removePlayerFromMyTeam`
- `TimeSlot::get_my_timeslots`
- `Team::getMyTeam`
- `MatchMgr::acceptReport`

La garde `!isTeamLeader()` qui suit reste en place : un admin **sans** équipe est toujours refusé, avec le bon message. Aucune occurrence équivalente côté frontend.

## Tests
- [x] 5 nouveaux tests dans `RolesTest` (TDD, RED→GREEN) : les 4 fonctions passent pour un cumul admin+responsable, et un admin pur reste refusé — **14/14 OK**
- [x] `php -l` sur les 4 classes modifiées

🤖 Generated with [Claude Code](https://claude.com/claude-code)