### PR TITLE
ci: tag semver automatique a chaque merge sur master

### DIFF
--- a/.github/ci/next-release.sh
+++ b/.github/ci/next-release.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# Calcule la prochaine version semver a partir des conventional commits, et
+# produit la section de CHANGELOG correspondante.
+#
+# Utilise par .github/workflows/auto-tag.yml, mais executable a la main pour
+# verifier ce que donnerait un merge sans rien pousser :
+#
+#     bash .github/ci/next-release.sh --dry-run
+#
+# Sorties (si $GITHUB_OUTPUT est defini) :
+#   version       -> ex. v1.2.0, vide si rien a publier
+#   previous_tag  -> tag de depart de la comparaison
+#   changelog     -> chemin du fichier contenant la section de CHANGELOG
+#
+# Regles de bump. Le semver strict ne bumpe que sur feat/fix, ce qui laisserait
+# les merges dependabot (chore(deps)) sans version alors que c'est precisement
+# le cas d'usage vise. On retient donc :
+#
+#   BREAKING CHANGE, ou type suivi de '!'  -> majeur
+#   feat                                    -> mineur
+#   tout le reste (fix, chore, deps, ci...) -> patch
+#
+# Autrement dit tout merge apportant au moins un commit produit un tag.
+
+set -euo pipefail
+
+DRY_RUN=0
+[ "${1:-}" = "--dry-run" ] && DRY_RUN=1
+
+CHANGELOG_SECTION="${RUNNER_TEMP:-/tmp}/changelog_section.md"
+
+# --- Point de depart -------------------------------------------------------
+# Seuls les tags semver comptent : les 48 tags horodates historiques
+# (YYYYMMDDHHMM) ne commencent pas par 'v' et sont donc ignores.
+previous_tag="$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n1 || true)"
+
+if [ -n "$previous_tag" ]; then
+    range="${previous_tag}..HEAD"
+    version_core="${previous_tag#v}"
+    major="${version_core%%.*}"
+    remainder="${version_core#*.}"
+    minor="${remainder%%.*}"
+    patch="${remainder#*.}"
+    first_release=0
+else
+    # Premier passage : on demarre a v1.0.0. On borne quand meme la lecture des
+    # commits au dernier tag horodate, sinon le CHANGELOG initial reprendrait
+    # toute l'histoire du depot.
+    last_any_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+    if [ -n "$last_any_tag" ]; then
+        range="${last_any_tag}..HEAD"
+    else
+        range="HEAD"
+    fi
+    previous_tag="$last_any_tag"
+    first_release=1
+fi
+
+commit_count="$(git log --no-merges --invert-grep --grep="^chore(release)" --format=%H "$range" | wc -l | tr -d ' ')"
+if [ "$commit_count" -eq 0 ]; then
+    echo "Aucun commit depuis ${previous_tag:-le debut} : rien a publier."
+    if [ -n "${GITHUB_OUTPUT:-}" ]; then
+        echo "version=" >> "$GITHUB_OUTPUT"
+    fi
+    exit 0
+fi
+
+# --- Niveau de bump --------------------------------------------------------
+bump="patch"
+
+while IFS= read -r subject; do
+    case "$subject" in
+        *!:*)
+            bump="major"
+            ;;
+        feat:*|feat\(*)
+            [ "$bump" = "major" ] || bump="minor"
+            ;;
+    esac
+done < <(git log --no-merges --invert-grep --grep="^chore(release)" --format=%s "$range")
+
+if git log --no-merges --invert-grep --grep="^chore(release)" --format=%B "$range" | grep -q '^BREAKING CHANGE'; then
+    bump="major"
+fi
+
+if [ "$first_release" -eq 1 ]; then
+    next_version="v1.0.0"
+else
+    case "$bump" in
+        major) major=$((major + 1)); minor=0; patch=0 ;;
+        minor) minor=$((minor + 1)); patch=0 ;;
+        patch) patch=$((patch + 1)) ;;
+    esac
+    next_version="v${major}.${minor}.${patch}"
+fi
+
+# --- Section de CHANGELOG --------------------------------------------------
+today="$(date +%Y-%m-%d)"
+{
+    echo "## ${next_version} — ${today}"
+    echo
+} > "$CHANGELOG_SECTION"
+
+# $1 = titre de section, $2..= motifs de sujet a retenir
+append_section() {
+    local title="$1"
+    shift
+    local matched=0
+    local body=""
+    while IFS= read -r subject; do
+        for pattern in "$@"; do
+            case "$subject" in
+                $pattern)
+                    body="${body}- ${subject}"$'\n'
+                    matched=1
+                    break
+                    ;;
+            esac
+        done
+    done < <(git log --no-merges --invert-grep --grep="^chore(release)" --format=%s --reverse "$range")
+    if [ "$matched" -eq 1 ]; then
+        {
+            echo "### ${title}"
+            echo
+            printf '%s' "$body"
+            echo
+        } >> "$CHANGELOG_SECTION"
+    fi
+}
+
+append_section "Fonctionnalites" 'feat:*' 'feat(*'
+append_section "Corrections" 'fix:*' 'fix(*'
+append_section "Dependances" 'chore(deps*' 'build(deps*' 'deps:*'
+append_section "Technique" 'ci:*' 'ci(*' 'refactor:*' 'refactor(*' 'perf:*' 'perf(*' \
+    'test:*' 'test(*' 'docs:*' 'docs(*' 'style:*' 'style(*' 'build:*' 'chore:*'
+
+echo "previous_tag = ${previous_tag:-<aucun>}"
+echo "bump         = ${bump}"
+echo "next_version = ${next_version}"
+echo "commits      = ${commit_count}"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    echo
+    echo "----- section de CHANGELOG -----"
+    cat "$CHANGELOG_SECTION"
+    exit 0
+fi
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+        echo "version=${next_version}"
+        echo "previous_tag=${previous_tag}"
+        echo "changelog=${CHANGELOG_SECTION}"
+    } >> "$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -18,6 +18,7 @@ on:
   push:
     branches:
       - master
+      - ci/auto-tag-semver  # TEMPORAIRE : validation avant merge, a retirer
   workflow_dispatch:
     inputs:
       dry_run:
@@ -53,7 +54,8 @@ jobs:
         run: bash .github/ci/next-release.sh
 
       - name: Push tag
-        if: steps.release.outputs.version != '' && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
+        # github.ref garantit qu'aucun tag ne peut sortir d'une branche de travail.
+        if: steps.release.outputs.version != '' && github.ref == 'refs/heads/master' && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
         env:
           VERSION: ${{ steps.release.outputs.version }}
           PREVIOUS_TAG: ${{ steps.release.outputs.previous_tag }}
@@ -64,7 +66,8 @@ jobs:
           git push origin "$VERSION"
 
       - name: Publish release notes
-        if: steps.release.outputs.version != '' && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
+        # github.ref garantit qu'aucun tag ne peut sortir d'une branche de travail.
+        if: steps.release.outputs.version != '' && github.ref == 'refs/heads/master' && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.release.outputs.version }}

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -18,7 +18,6 @@ on:
   push:
     branches:
       - master
-      - ci/auto-tag-semver  # TEMPORAIRE : validation avant merge, a retirer
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,101 @@
+name: Auto-tag semver
+
+# A chaque merge sur master : rejoue la suite PHPUnit, puis calcule et pose un
+# tag semver derive des conventional commits, avec les notes de version
+# correspondantes publiees en Release GitHub.
+#
+# Ne deploie PAS. Le tag est pousse avec le GITHUB_TOKEN, et GitHub ne
+# redeclenche volontairement aucun workflow sur un push fait avec ce jeton :
+# main.yml reste donc silencieux. Pour mettre en prod, lancer "CI/CD Workflow"
+# a la main depuis l'onglet Actions en choisissant le tag voulu comme ref.
+#
+# Pourquoi une Release et pas un CHANGELOG.md versionne : master exige une PR
+# avec review, donc github-actions[bot] ne peut pas y pousser de commit. Les
+# tags, eux, ne sont pas couverts par la protection de branche. Si la
+# protection venait a autoriser le bot, le fichier redeviendrait possible.
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Calculer la version sans poser de tag ni publier de Release"
+        type: boolean
+        default: true
+
+permissions:
+  contents: write  # pousser le tag et creer la Release
+
+concurrency:
+  group: auto-tag
+  cancel-in-progress: false  # deux merges rapproches doivent tagger chacun leur tour
+
+jobs:
+  tests:
+    # Meme job que sur les PR : rien n'est tagge si la suite est rouge.
+    uses: ./.github/workflows/tests.yml
+
+  tag:
+    name: Tag semver
+    needs: tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # historique complet + tags : necessaire au calcul de version
+
+      - name: Compute next version
+        id: release
+        run: bash .github/ci/next-release.sh
+
+      - name: Push tag
+        if: steps.release.outputs.version != '' && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+          PREVIOUS_TAG: ${{ steps.release.outputs.previous_tag }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$VERSION" -m "$VERSION (depuis ${PREVIOUS_TAG:-le debut})"
+          git push origin "$VERSION"
+
+      - name: Publish release notes
+        if: steps.release.outputs.version != '' && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.release.outputs.version }}
+          SECTION: ${{ steps.release.outputs.changelog }}
+        run: |
+          # La section commence par un titre "## vX.Y.Z — date" redondant avec
+          # le titre de la Release : on ne garde que le corps.
+          tail -n +2 "$SECTION" > release_notes.md
+          gh release create "$VERSION" \
+            --title "$VERSION" \
+            --notes-file release_notes.md
+
+      - name: Summary
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+        run: |
+          if [ -z "$VERSION" ]; then
+            echo "Aucun commit publiable : pas de tag." >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$DRY_RUN" = "true" ]; then
+            {
+              echo "## Simulation : \`$VERSION\` serait pose"
+              echo
+              echo "Aucun tag ni Release n'a ete cree."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "## Tag \`$VERSION\` pose"
+              echo
+              echo "Deploiement **non** declenche."
+              echo "Pour mettre en prod : onglet Actions -> CI/CD Workflow ->"
+              echo "Run workflow -> ref \`$VERSION\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,8 @@ on:
   pull_request:
   push:
     branches-ignore:
-      - master  # master est couvert au moment du tag par main.yml
+      - master  # sur master, la suite est rejouee par auto-tag.yml avant de tagger
+  workflow_call:  # appele par auto-tag.yml : pas de tag si la suite est rouge
 
 jobs:
   phpunit:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,9 +161,39 @@ npm run build
 
 **Hors périmètre du bundle Vite** : `admin.php`, `register.php`, `reset_password.php`, `rank_for_cup.php` — restent sur les CDN ExtJS (interface d'administration historique).
 
-### Déployer en production
+### Versionner et déployer
+
+**Le tag est automatique.** À chaque merge sur `master`, `.github/workflows/auto-tag.yml`
+rejoue la suite PHPUnit, calcule la version suivante depuis les conventional
+commits et pose le tag + une Release GitHub contenant les notes de version.
+
+Règles de bump (`.github/ci/next-release.sh`) — le semver strict ne bumpe que
+sur `feat`/`fix`, ce qui laisserait les merges dependabot sans version :
+
+| Commit | Bump |
+|--------|------|
+| `BREAKING CHANGE` en corps, ou type suivi de `!` | majeur |
+| `feat` | mineur |
+| tout le reste (`fix`, `chore(deps)`, `ci`…) | patch |
+
+Prévisualiser sans rien pousser :
 ```bash
-# Créer un tag pour déclencher le CI/CD
+bash .github/ci/next-release.sh --dry-run
+```
+
+**Le déploiement reste manuel.** Le tag est poussé avec le `GITHUB_TOKEN`, et
+GitHub ne redéclenche aucun workflow sur un push fait avec ce jeton : `main.yml`
+ne part donc pas tout seul. Pour mettre en prod : onglet Actions → *CI/CD
+Workflow* → **Run workflow** → choisir le tag comme ref.
+
+> Deux conséquences de la protection de `master` (PR + 1 review) :
+> `github-actions[bot]` ne peut pas y pousser de commit, d'où les notes de
+> version en Release plutôt qu'un `CHANGELOG.md` versionné.
+> Les 48 tags horodatés historiques (`YYYYMMDDHHMM`) cohabitent sans souci :
+> le script ne considère que les tags commençant par `v`.
+
+Poser un tag à la main reste possible :
+```bash
 git tag v1.2.3
 git push origin v1.2.3
 ```


### PR DESCRIPTION
## Contexte

Les 48 tags du dépôt sont des horodatages `YYYYMMDDHHMM` posés à la main, et rien ne versionnait le dépôt après un merge dependabot. Suite de la PR #256, qui a rendu les tests unitaires exécutables en CI.

## Ce que fait cette PR

`auto-tag.yml` : à chaque merge sur `master`, la suite PHPUnit est rejouée, puis la version suivante est calculée depuis les conventional commits, le tag posé et les notes de version publiées en Release GitHub.

`tests.yml` gagne un trigger `workflow_call` pour être réutilisé — rien n'est taggé si la suite est rouge.

## Règles de bump

Le semver strict ne bumpe que sur `feat`/`fix`, ce qui laisserait précisément les merges dependabot (`chore(deps)`) sans version. D'où :

| Commit | Bump |
|--------|------|
| `BREAKING CHANGE` en corps, ou type suivi de `!` | majeur |
| `feat` | mineur |
| tout le reste (`fix`, `chore(deps)`, `ci`…) | patch |

Autrement dit, tout merge apportant au moins un commit produit un tag. Les 48 tags horodatés cohabitent sans souci : le script ne considère que les tags commençant par `v`. Le premier tag posé sera `v1.0.0`.

Prévisualisable hors CI :

```
bash .github/ci/next-release.sh --dry-run
```

## Le déploiement reste manuel

Le tag est poussé avec le `GITHUB_TOKEN`, et GitHub ne redéclenche volontairement aucun workflow sur un push fait avec ce jeton : `main.yml` ne part donc pas tout seul. C'est ce comportement qui porte la garantie « tag sans déploiement » — passer un jour à un PAT rendrait les déploiements automatiques.

Pour mettre en prod : onglet Actions → *CI/CD Workflow* → **Run workflow** → choisir le tag comme ref.

## Notes de version en Release, pas en `CHANGELOG.md`

`master` exige une PR avec review, donc `github-actions[bot]` ne peut pas y pousser de commit. Les tags, eux, ne sont pas couverts par la protection de branche. Si tu autorises un jour le bot à bypasser, on peut basculer sur un `CHANGELOG.md` versionné.

## Validation

Le workflow a tourné en entier sur cette branche via un trigger temporaire (retiré depuis) : `tests / PHPUnit` vert en 1 min 5 s, puis `Tag semver` qui a calculé `v1.0.0` sans rien poser, le garde-fou `github.ref == 'refs/heads/master'` ayant fait son office. Aucun tag `v*` n'existe sur le remote.

Les cinq règles de bump ont été vérifiées sur un dépôt jetable : `chore(deps)` seul → patch, `+ fix` → patch, `+ feat` → mineur, `refactor!:` → majeur, `BREAKING CHANGE` en corps → majeur.

Le workflow est aussi lançable à la main en mode simulation (`dry_run`, coché par défaut).
