### PR TITLE
Feat #253: calendrier de la home stocke en base et gerable depuis l'administration

### DIFF
--- a/.github/ci/schema.sql
+++ b/.github/ci/schema.sql
@@ -116,6 +116,24 @@ CREATE TABLE `blacklist_teams` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
+-- Table structure for table `calendar_events`
+--
+
+DROP TABLE IF EXISTS `calendar_events`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `calendar_events` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `season` varchar(9) NOT NULL COMMENT 'ex. 2026-2027',
+  `label` varchar(100) NOT NULL,
+  `date_start` datetime NOT NULL,
+  `date_end` datetime DEFAULT NULL COMMENT 'NULL = evenement ponctuel',
+  PRIMARY KEY (`id`),
+  KEY `idx_calendar_events_season` (`season`,`date_start`)
+) ENGINE=InnoDB AUTO_INCREMENT=46 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Table structure for table `classements`
 --
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,7 @@ test.afterAll(async ({ request }) => {
 - `finals_setup.php` / `finals_teardown.php` — matchs 1/8 finale KF/CF (issue #215)
 - `messages_setup.php` / `messages_teardown.php` — emails non lus pour responsable d'équipe (issue #221)
 - `today_matches_setup.php` / `today_matches_teardown.php` — match programmé aujourd'hui + une nouvelle, pour l'encart "Matchs du jour" et les nouvelles repliables de la home (issue #230). Le setup recopie les FK d'un match déjà visible dans `matchs_view` (échantillonnage **depuis la vue**, pas la table `matches`, pour éviter les matchs orphelins).
+- `calendar_events_setup.php` / `calendar_events_teardown.php` — trois événements de calendrier dans la saison en cours, pour le calendrier de la home alimenté en base (issue #253). Les dates sont posées en novembre de l'année d'ouverture de saison, donc toujours dans les mois affichés ; le test déplie les mois passés pour ne pas dépendre du jour d'exécution.
 
 ### Installer les dépendances PHP
 ```bash

--- a/classes/CalendarEvents.php
+++ b/classes/CalendarEvents.php
@@ -1,0 +1,172 @@
+<?php
+require_once __DIR__ . '/Generic.php';
+
+/**
+ * Evenements du calendrier de la page d'accueil (issue #253).
+ *
+ * Ils etaient codes en dur dans pages/components/panel/Home.js ; ils vivent
+ * desormais en base et se gerent depuis l'administration.
+ */
+class CalendarEvents extends Generic
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->table_name = 'calendar_events';
+    }
+
+    /**
+     * Saison en cours, au format '2026-2027'.
+     *
+     * Meme regle que le front (AnnualCalendar.js) : de janvier a juin on est
+     * encore dans la saison ouverte l'annee precedente ; des juillet, on bascule
+     * sur la suivante.
+     */
+    public static function getCurrentSeason(): string
+    {
+        $startYear = ((int)date('n') <= 6) ? (int)date('Y') - 1 : (int)date('Y');
+        return $startYear . '-' . ($startYear + 1);
+    }
+
+    /**
+     * Lecture publique, consommee par le calendrier de la home.
+     *
+     * Les dates sortent au format attendu par AnnualCalendar.js, soit
+     * 'd/m/Y H:i'. Exception : une heure a minuit signifie "toute la journee"
+     * et sort sans heure, sinon les feries s'afficheraient "a 00:00".
+     *
+     * @throws Exception
+     */
+    public function getCalendarEvents($season = null): array
+    {
+        if (empty($season)) {
+            $season = self::getCurrentSeason();
+        }
+        // Les colonnes du ORDER BY sont qualifiees : sans cela MySQL trierait
+        // sur les alias, donc sur la date formatee en jj/mm/aaaa, c'est-a-dire
+        // sur du texte (le 02/11 passerait avant le 03/09).
+        $sql = "SELECT
+                    ce.id,
+                    ce.season,
+                    ce.label,
+                    IF(TIME(ce.date_start) = '00:00:00',
+                       DATE_FORMAT(ce.date_start, '%d/%m/%Y'),
+                       DATE_FORMAT(ce.date_start, '%d/%m/%Y %H:%i')) AS date_start,
+                    IF(TIME(ce.date_end) = '00:00:00',
+                       DATE_FORMAT(ce.date_end, '%d/%m/%Y'),
+                       DATE_FORMAT(ce.date_end, '%d/%m/%Y %H:%i')) AS date_end
+                FROM calendar_events ce
+                WHERE ce.season = ?
+                ORDER BY ce.date_start, ce.id";
+        $bindings = array(
+            array('type' => 's', 'value' => $season)
+        );
+        return $this->sql_manager->execute($sql, $bindings);
+    }
+
+    /**
+     * Liste complete pour la grille d'administration, dates au format ISO
+     * attendu par le modele ExtJS.
+     *
+     * @throws Exception
+     */
+    public function getAllCalendarEvents(): array
+    {
+        $sql = "SELECT
+                    ce.id,
+                    ce.season,
+                    ce.label,
+                    DATE_FORMAT(ce.date_start, '%Y-%m-%d %H:%i:%s') AS date_start,
+                    DATE_FORMAT(ce.date_end, '%Y-%m-%d %H:%i:%s') AS date_end
+                FROM calendar_events ce
+                ORDER BY ce.season DESC, ce.date_start, ce.id";
+        return $this->sql_manager->execute($sql);
+    }
+
+    /**
+     * Saisons presentes en base, la plus recente d'abord.
+     *
+     * @throws Exception
+     */
+    public function getSeasons(): array
+    {
+        $sql = "SELECT DISTINCT season FROM calendar_events ORDER BY season DESC";
+        return $this->sql_manager->execute($sql);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function saveCalendarEvent(
+        $id = null,
+        $season = '',
+        $label = '',
+        $date_start = null,
+        $date_end = null,
+        $dirtyFields = null
+    ): void
+    {
+        @session_start();
+        if (!UserManager::isAdmin()) {
+            throw new Exception("Seuls les administrateurs peuvent modifier le calendrier");
+        }
+        if (empty($season)) {
+            throw new Exception("La saison est obligatoire");
+        }
+        if (empty($label)) {
+            throw new Exception("Le libelle est obligatoire");
+        }
+        if (empty($date_start)) {
+            throw new Exception("La date de debut est obligatoire");
+        }
+        // Une periode qui se termine avant d'avoir commence n'afficherait rien.
+        if (!empty($date_end) && strtotime($date_end) < strtotime($date_start)) {
+            throw new Exception("La date de fin doit etre posterieure a la date de debut");
+        }
+
+        // Un champ vide venu du formulaire vaut "evenement ponctuel".
+        $date_end = empty($date_end) ? null : $date_end;
+
+        if (!empty($id) && is_numeric($id)) {
+            $sql = "UPDATE calendar_events
+                    SET season = ?, label = ?, date_start = ?, date_end = ?
+                    WHERE id = ?";
+            $bindings = array(
+                array('type' => 's', 'value' => $season),
+                array('type' => 's', 'value' => $label),
+                array('type' => 's', 'value' => $date_start),
+                array('type' => 's', 'value' => $date_end),
+                array('type' => 'i', 'value' => $id)
+            );
+        } else {
+            $sql = "INSERT INTO calendar_events (season, label, date_start, date_end)
+                    VALUES (?, ?, ?, ?)";
+            $bindings = array(
+                array('type' => 's', 'value' => $season),
+                array('type' => 's', 'value' => $label),
+                array('type' => 's', 'value' => $date_start),
+                array('type' => 's', 'value' => $date_end)
+            );
+        }
+        $this->sql_manager->execute($sql, $bindings);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function deleteCalendarEvent($id = null): void
+    {
+        @session_start();
+        if (!UserManager::isAdmin()) {
+            throw new Exception("Seuls les administrateurs peuvent supprimer un evenement");
+        }
+        if (empty($id) || !is_numeric($id)) {
+            throw new Exception("Identifiant d'evenement invalide");
+        }
+        $sql = "DELETE FROM calendar_events WHERE id = ?";
+        $bindings = array(
+            array('type' => 'i', 'value' => $id)
+        );
+        $this->sql_manager->execute($sql, $bindings);
+    }
+}

--- a/e2e/helpers/calendar_events_setup.php
+++ b/e2e/helpers/calendar_events_setup.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * E2E test helper (#253) — insère un événement de calendrier connu dans la
+ * saison en cours, pour vérifier que la home lit bien le calendrier en base.
+ *
+ * La date est fixée au 15 novembre de l'année d'ouverture de la saison : elle
+ * tombe donc toujours dans les mois affichés par AnnualCalendar (septembre à
+ * juin), quelle que soit la date d'exécution du test. Le test déplie les mois
+ * passés avant d'assertionner, ce qui le rend indépendant du jour de passage.
+ *
+ * SECURITY: ne doit jamais être déployé en production.
+ */
+$isLocalhost = in_array($_SERVER['REMOTE_ADDR'] ?? '', ['127.0.0.1', '::1'], true);
+$isTestEnv   = getenv('APP_ENV') === 'test';
+if (!$isLocalhost && !$isTestEnv) {
+    http_response_code(403);
+    exit('Forbidden');
+}
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../classes/CalendarEvents.php';
+
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/../../');
+$dotenv->load();
+
+header('Content-Type: application/json');
+
+const E2E_POINT_LABEL  = 'E2E Evenement ponctuel';
+const E2E_PERIOD_LABEL = 'E2E Periode test';
+const E2E_ALLDAY_LABEL = 'E2E Journee entiere';
+
+try {
+    $sql = new SqlManager();
+
+    $season = CalendarEvents::getCurrentSeason();
+    $startYear = (int)explode('-', $season)[0];
+
+    // Nettoyage préventif si un run précédent s'est interrompu.
+    $sql->execute(
+        "DELETE FROM calendar_events WHERE label IN (?, ?, ?)",
+        [
+            ['type' => 's', 'value' => E2E_POINT_LABEL],
+            ['type' => 's', 'value' => E2E_PERIOD_LABEL],
+            ['type' => 's', 'value' => E2E_ALLDAY_LABEL],
+        ]
+    );
+
+    $rows = [
+        // Ponctuel avec heure : la home doit afficher l'heure.
+        [E2E_POINT_LABEL, "$startYear-11-15 19:30:00", null],
+        // Période : la home doit afficher un intervalle de dates.
+        [E2E_PERIOD_LABEL, "$startYear-11-03 00:00:00", "$startYear-11-20 23:59:00"],
+        // Ponctuel à minuit : la home ne doit PAS afficher "à 00:00".
+        [E2E_ALLDAY_LABEL, "$startYear-11-11 00:00:00", null],
+    ];
+    foreach ($rows as $row) {
+        $sql->execute(
+            "INSERT INTO calendar_events (season, label, date_start, date_end) VALUES (?, ?, ?, ?)",
+            [
+                ['type' => 's', 'value' => $season],
+                ['type' => 's', 'value' => $row[0]],
+                ['type' => 's', 'value' => $row[1]],
+                ['type' => 's', 'value' => $row[2]],
+            ]
+        );
+    }
+
+    echo json_encode([
+        'success' => true,
+        'season' => $season,
+        'point_label' => E2E_POINT_LABEL,
+        'period_label' => E2E_PERIOD_LABEL,
+        'allday_label' => E2E_ALLDAY_LABEL,
+    ]);
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}

--- a/e2e/helpers/calendar_events_teardown.php
+++ b/e2e/helpers/calendar_events_teardown.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * E2E test helper (#253) — supprime les événements de calendrier créés par
+ * calendar_events_setup.php.
+ *
+ * SECURITY: ne doit jamais être déployé en production.
+ */
+$isLocalhost = in_array($_SERVER['REMOTE_ADDR'] ?? '', ['127.0.0.1', '::1'], true);
+$isTestEnv   = getenv('APP_ENV') === 'test';
+if (!$isLocalhost && !$isTestEnv) {
+    http_response_code(403);
+    exit('Forbidden');
+}
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../classes/SqlManager.php';
+
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/../../');
+$dotenv->load();
+
+header('Content-Type: application/json');
+
+try {
+    $sql = new SqlManager();
+    $sql->execute("DELETE FROM calendar_events WHERE label LIKE 'E2E %'");
+    echo json_encode(['success' => true]);
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}

--- a/e2e/tests/issue_253.spec.js
+++ b/e2e/tests/issue_253.spec.js
@@ -1,0 +1,85 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+/**
+ * E2E — Calendrier de la home alimenté depuis la base (issue #253)
+ *
+ *  1. Setup : insérer trois événements connus dans la saison en cours
+ *     (ponctuel avec heure, période, ponctuel « journée entière »).
+ *  2. Ouvrir la home et vérifier que le calendrier les affiche, ce qui prouve
+ *     que les données viennent bien de la base et non du tableau supprimé
+ *     de Home.js.
+ *  3. Vérifier la régression des fériés : un ponctuel à minuit ne doit pas
+ *     s'afficher « à 00:00 ».
+ *  4. Teardown : supprimer les événements de test.
+ */
+
+test.describe('Issue #253 — Calendrier de la home en base', () => {
+    let season = null;
+    let pointLabel = null;
+    let periodLabel = null;
+    let alldayLabel = null;
+
+    test.beforeAll(async ({ request }) => {
+        const res = await request.get('/e2e/helpers/calendar_events_setup.php');
+        const body = await res.json();
+        if (body.error) throw new Error(`Setup failed: ${body.error}`);
+        expect(res.status()).toBe(200);
+        expect(body.success).toBe(true);
+        season = body.season;
+        pointLabel = body.point_label;
+        periodLabel = body.period_label;
+        alldayLabel = body.allday_label;
+    });
+
+    test.afterAll(async ({ request }) => {
+        await request.get('/e2e/helpers/calendar_events_teardown.php');
+    });
+
+    /**
+     * Les événements de test sont posés en novembre. Selon la date d'exécution
+     * ce mois peut être passé, donc masqué par défaut : on déplie d'abord.
+     */
+    async function openCalendarWithPastMonths(page) {
+        await page.goto('/pages/home.html#/home');
+        await expect(page.getByText(`calendrier ${season}`)).toBeVisible({ timeout: 10000 });
+
+        const toggle = page.getByRole('button', { name: /Afficher les mois passés/ });
+        if (await toggle.isVisible().catch(() => false)) {
+            await toggle.click();
+        }
+    }
+
+    test('le calendrier affiche les événements lus en base', async ({ page }) => {
+        await openCalendarWithPastMonths(page);
+
+        await expect(page.getByText(pointLabel).first()).toBeVisible({ timeout: 10000 });
+        await expect(page.getByText(periodLabel).first()).toBeVisible();
+
+        await page.screenshot({
+            path: 'test-results/issue-253/calendrier_depuis_la_base.png',
+            fullPage: true
+        });
+    });
+
+    test('un événement ponctuel affiche son heure', async ({ page }) => {
+        await openCalendarWithPastMonths(page);
+
+        const entry = page.locator('div.rounded.border-l-4', { hasText: pointLabel }).first();
+        await expect(entry).toBeVisible({ timeout: 10000 });
+        await expect(entry).toContainText('19:30');
+    });
+
+    test('un événement sur la journée entière n\'affiche pas 00:00', async ({ page }) => {
+        await openCalendarWithPastMonths(page);
+
+        const entry = page.locator('div.rounded.border-l-4', { hasText: alldayLabel }).first();
+        await expect(entry).toBeVisible({ timeout: 10000 });
+        await expect(entry).not.toContainText('00:00');
+
+        await page.screenshot({
+            path: 'test-results/issue-253/journee_entiere_sans_heure.png',
+            fullPage: true
+        });
+    });
+});

--- a/js/administration.js
+++ b/js/administration.js
@@ -170,6 +170,11 @@ Ext.application({
                                         text: 'Gestion des news',
                                         glyph: 'xf1ea@FontAwesome',
                                         action: 'manageNews'
+                                    },
+                                    {
+                                        text: 'Calendrier de la page d\'accueil',
+                                        glyph: 'xf133@FontAwesome',
+                                        action: 'manageCalendarEvents'
                                     }
                                 ]
                             },

--- a/js/controller/Administration.js
+++ b/js/controller/Administration.js
@@ -1,8 +1,8 @@
 Ext.define('Ufolep13Volley.controller.Administration', {
     extend: 'Ext.app.Controller',
-    stores: ['Players', 'Clubs', 'Teams', 'RankTeams', 'Competitions', 'ParentCompetitions', 'Users', 'Gymnasiums', 'Activity', 'WeekSchedule', 'AdminMatches', 'AdminDays', 'LimitDates', 'AdminRanks', 'HallOfFame', 'Timeslots', 'BlacklistGymnase', 'BlacklistTeam', 'BlacklistTeams', 'BlacklistDate', 'Departements', 'AdminNews'],
-    models: ['Player', 'Club', 'Team', 'RankTeam', 'Competition', 'User', 'Gymnasium', 'Activity', 'WeekSchedule', 'Match', 'WeekDay', 'Day', 'LimitDate', 'Rank', 'HallOfFame', 'Timeslot', 'BlacklistGymnase', 'BlacklistTeam', 'BlacklistTeams', 'BlacklistDate', 'News'],
-    views: ['player.Grid', 'player.Edit', 'club.Select', 'team.Select', 'team.Grid', 'team.Edit', 'match.AdminGrid', 'match.Edit', 'day.AdminGrid', 'day.Edit', 'limitdate.Grid', 'limitdate.Edit', 'user.Grid', 'user.Edit', 'gymnasium.Grid', 'gymnasium.Edit', 'club.Grid', 'club.Edit', 'activity.Grid', 'timeslot.WeekScheduleGrid', 'rank.AdminGrid', 'rank.Edit', 'rank.DragDropPanel', 'grid.HallOfFame', 'window.HallOfFame', 'grid.Competitions', 'window.Competition', 'grid.BlacklistGymnase', 'window.BlacklistGymnase', 'grid.BlacklistTeam', 'window.BlacklistTeam', 'grid.BlacklistTeams', 'window.BlacklistTeams', 'grid.BlacklistDate', 'window.BlacklistDate', 'grid.Timeslots', 'window.Timeslot', 'view.Indicators', 'news.AdminGrid', 'news.Edit', 'bilan.Form'],
+    stores: ['Players', 'Clubs', 'Teams', 'RankTeams', 'Competitions', 'ParentCompetitions', 'Users', 'Gymnasiums', 'Activity', 'WeekSchedule', 'AdminMatches', 'AdminDays', 'LimitDates', 'AdminRanks', 'HallOfFame', 'Timeslots', 'BlacklistGymnase', 'BlacklistTeam', 'BlacklistTeams', 'BlacklistDate', 'Departements', 'AdminNews', 'AdminCalendarEvents'],
+    models: ['Player', 'Club', 'Team', 'RankTeam', 'Competition', 'User', 'Gymnasium', 'Activity', 'WeekSchedule', 'Match', 'WeekDay', 'Day', 'LimitDate', 'Rank', 'HallOfFame', 'Timeslot', 'BlacklistGymnase', 'BlacklistTeam', 'BlacklistTeams', 'BlacklistDate', 'News', 'CalendarEvent'],
+    views: ['player.Grid', 'player.Edit', 'club.Select', 'team.Select', 'team.Grid', 'team.Edit', 'match.AdminGrid', 'match.Edit', 'day.AdminGrid', 'day.Edit', 'limitdate.Grid', 'limitdate.Edit', 'user.Grid', 'user.Edit', 'gymnasium.Grid', 'gymnasium.Edit', 'club.Grid', 'club.Edit', 'activity.Grid', 'timeslot.WeekScheduleGrid', 'rank.AdminGrid', 'rank.Edit', 'rank.DragDropPanel', 'grid.HallOfFame', 'window.HallOfFame', 'grid.Competitions', 'window.Competition', 'grid.BlacklistGymnase', 'window.BlacklistGymnase', 'grid.BlacklistTeam', 'window.BlacklistTeam', 'grid.BlacklistTeams', 'window.BlacklistTeams', 'grid.BlacklistDate', 'window.BlacklistDate', 'grid.Timeslots', 'window.Timeslot', 'view.Indicators', 'news.AdminGrid', 'news.Edit', 'calendar_events.AdminGrid', 'calendar_events.Edit', 'bilan.Form'],
     refs: [{
         ref: 'ImagePlayer', selector: 'playeredit image'
     }, {
@@ -75,6 +75,12 @@ Ext.define('Ufolep13Volley.controller.Administration', {
         ref: 'windowEditNews', selector: 'newsedit'
     }, {
         ref: 'manageNewsGrid', selector: 'newsgrid'
+    }, {
+        ref: 'formPanelEditCalendarEvents', selector: 'calendareventsedit form'
+    }, {
+        ref: 'windowEditCalendarEvents', selector: 'calendareventsedit'
+    }, {
+        ref: 'manageCalendarEventsGrid', selector: 'calendareventsgrid'
     }],
     init: function () {
         this.control({
@@ -306,6 +312,20 @@ Ext.define('Ufolep13Volley.controller.Administration', {
                 click: this.deleteNews
             }, 'newsgrid': {
                 itemdblclick: this.editNews
+            }, 'menuitem[action=manageCalendarEvents]': {
+                click: this.showCalendarEventsGrid
+            }, 'button[action=addCalendarEvent]': {
+                click: this.addCalendarEvent
+            }, 'button[action=editCalendarEvent]': {
+                click: this.editCalendarEvent
+            }, 'button[action=deleteCalendarEvent]': {
+                click: this.deleteCalendarEvent
+            }, 'calendareventsgrid': {
+                itemdblclick: this.editCalendarEvent
+            }, 'calendareventsedit datefield': {
+                change: this.syncCalendarEventDateTime
+            }, 'calendareventsedit timefield': {
+                change: this.syncCalendarEventDateTime
             }
         });
     },
@@ -1554,6 +1574,111 @@ Ext.define('Ufolep13Volley.controller.Administration', {
             }]
         });
         selectWindow.show();
+    },
+    showCalendarEventsGrid: function () {
+        this.showAdministrationGrid('calendareventsgrid');
+    },
+    /**
+     * Recompose les champs cachés date_start / date_end à partir des couples
+     * date + heure du formulaire. L'API ne reçoit ainsi qu'une date complète,
+     * ExtJS classic n'ayant pas de champ datetime.
+     */
+    applyCalendarEventDateTime: function (basicForm) {
+        Ext.each(['date_start', 'date_end'], function (prefix) {
+            var hidden = basicForm.findField(prefix);
+            var dateField = basicForm.findField(prefix + '_date');
+            var timeField = basicForm.findField(prefix + '_time');
+            if (!hidden || !dateField) {
+                return;
+            }
+            var dateValue = dateField.getValue();
+            if (!dateValue) {
+                // Pas de date de fin = événement ponctuel.
+                hidden.setValue('');
+                return;
+            }
+            var timeValue = timeField ? timeField.getValue() : null;
+            // Heure vide = journée entière : minuit, que l'API renverra sans heure.
+            var time = timeValue ? Ext.Date.format(timeValue, 'H:i') : '00:00';
+            hidden.setValue(Ext.Date.format(dateValue, 'Y-m-d') + ' ' + time + ':00');
+        });
+    },
+    syncCalendarEventDateTime: function (field) {
+        var form = field.up('form');
+        if (form) {
+            this.applyCalendarEventDateTime(form.getForm());
+        }
+    },
+    fillCalendarEventDateFields: function (basicForm, record) {
+        Ext.each(['date_start', 'date_end'], function (prefix) {
+            var dateField = basicForm.findField(prefix + '_date');
+            var timeField = basicForm.findField(prefix + '_time');
+            var value = record ? record.get(prefix) : null;
+            if (!value) {
+                if (dateField) {
+                    dateField.setValue(null);
+                }
+                if (timeField) {
+                    timeField.setValue(null);
+                }
+                return;
+            }
+            if (dateField) {
+                dateField.setValue(value);
+            }
+            if (timeField) {
+                var isMidnight = value.getHours() === 0 && value.getMinutes() === 0;
+                timeField.setValue(isMidnight ? null : Ext.Date.format(value, 'H:i'));
+            }
+        });
+    },
+    addCalendarEvent: function () {
+        Ext.widget('calendareventsedit');
+        var basicForm = this.getFormPanelEditCalendarEvents().getForm();
+        // Pré-remplit la saison en cours, même bascule qu'en juillet côté home.
+        var now = new Date();
+        var startYear = now.getMonth() <= 5 ? now.getFullYear() - 1 : now.getFullYear();
+        basicForm.findField('season').setValue(startYear + '-' + (startYear + 1));
+    },
+    editCalendarEvent: function (button) {
+        var grid = button.up('grid');
+        var record = grid.getSelectionModel().getSelection()[0];
+        if (!record) {
+            Ext.Msg.alert('Erreur', 'Veuillez sélectionner un événement');
+            return;
+        }
+        Ext.widget('calendareventsedit');
+        var formPanel = this.getFormPanelEditCalendarEvents();
+        formPanel.loadRecord(record);
+        var basicForm = formPanel.getForm();
+        this.fillCalendarEventDateFields(basicForm, record);
+        // loadRecord a posé des objets Date dans les champs cachés : on les
+        // repasse au format attendu par MySQL avant tout envoi.
+        this.applyCalendarEventDateTime(basicForm);
+    },
+    deleteCalendarEvent: function (button) {
+        var grid = button.up('grid');
+        var record = grid.getSelectionModel().getSelection()[0];
+        if (!record) {
+            Ext.Msg.alert('Erreur', 'Veuillez sélectionner un événement');
+            return;
+        }
+        Ext.Msg.confirm('Confirmation', 'Voulez-vous vraiment supprimer cet événement ?', function (btn) {
+            if (btn === 'yes') {
+                Ext.Ajax.request({
+                    url: '/rest/action.php/calendarevents/deleteCalendarEvent',
+                    method: 'POST',
+                    params: {id: record.get('id')},
+                    success: function () {
+                        grid.getStore().load();
+                    },
+                    failure: function (response) {
+                        var result = Ext.decode(response.responseText);
+                        Ext.Msg.alert('Erreur', result.message);
+                    }
+                });
+            }
+        });
     },
     showNewsGrid: function () {
         var mainPanel = this.getMainPanel();

--- a/js/model/CalendarEvent.js
+++ b/js/model/CalendarEvent.js
@@ -1,0 +1,28 @@
+Ext.define('Ufolep13Volley.model.CalendarEvent', {
+    extend: 'Ext.data.Model',
+    fields: [
+        {
+            name: 'id',
+            type: 'int'
+        },
+        {
+            name: 'season',
+            type: 'string'
+        },
+        {
+            name: 'label',
+            type: 'string'
+        },
+        {
+            name: 'date_start',
+            type: 'date',
+            dateFormat: 'Y-m-d H:i:s'
+        },
+        {
+            name: 'date_end',
+            type: 'date',
+            dateFormat: 'Y-m-d H:i:s',
+            allowNull: true
+        }
+    ]
+});

--- a/js/store/AdminCalendarEvents.js
+++ b/js/store/AdminCalendarEvents.js
@@ -1,0 +1,15 @@
+Ext.define('Ufolep13Volley.store.AdminCalendarEvents', {
+    extend: 'Ext.data.Store',
+    alias: 'store.AdminCalendarEvents',
+    config: {
+        model: 'Ufolep13Volley.model.CalendarEvent',
+        proxy: {
+            type: 'ajax',
+            url: '/rest/action.php/calendarevents/getAllCalendarEvents',
+            reader: {
+                type: 'json'
+            }
+        },
+        autoLoad: true
+    }
+});

--- a/js/view/calendar_events/AdminGrid.js
+++ b/js/view/calendar_events/AdminGrid.js
@@ -1,0 +1,67 @@
+Ext.define('Ufolep13Volley.view.calendar_events.AdminGrid', {
+    extend: 'Ufolep13Volley.view.grid.ufolep',
+    alias: 'widget.calendareventsgrid',
+    title: 'Calendrier de la page d\'accueil',
+    store: {type: 'AdminCalendarEvents'},
+    columns: {
+        items: [
+            {
+                header: 'ID',
+                dataIndex: 'id',
+                width: 60
+            },
+            {
+                header: 'Saison',
+                dataIndex: 'season',
+                width: 110
+            },
+            {
+                header: 'Libellé',
+                dataIndex: 'label',
+                flex: 1
+            },
+            {
+                header: 'Début',
+                dataIndex: 'date_start',
+                width: 150,
+                renderer: Ext.util.Format.dateRenderer('d/m/Y H:i')
+            },
+            {
+                header: 'Fin',
+                dataIndex: 'date_end',
+                width: 150,
+                // Vide = événement ponctuel, affiché comme un point sur la home.
+                renderer: function (value) {
+                    return value ? Ext.Date.format(value, 'd/m/Y H:i') : '(ponctuel)';
+                }
+            }
+        ]
+    },
+    dockedItems: [
+        {
+            xtype: 'toolbar',
+            dock: 'top',
+            items: [
+                'ACTIONS',
+                {
+                    xtype: 'tbseparator'
+                },
+                {
+                    text: 'Ajouter un événement',
+                    glyph: 'xf067@FontAwesome',
+                    action: 'addCalendarEvent'
+                },
+                {
+                    text: 'Editer',
+                    glyph: 'xf044@FontAwesome',
+                    action: 'editCalendarEvent'
+                },
+                {
+                    text: 'Supprimer',
+                    glyph: 'xf1f8@FontAwesome',
+                    action: 'deleteCalendarEvent'
+                }
+            ]
+        }
+    ]
+});

--- a/js/view/calendar_events/Edit.js
+++ b/js/view/calendar_events/Edit.js
@@ -1,0 +1,103 @@
+Ext.define('Ufolep13Volley.view.calendar_events.Edit', {
+    extend: 'Ext.window.Window',
+    alias: 'widget.calendareventsedit',
+    title: "Modification de l'événement",
+    height: 380,
+    width: 620,
+    modal: true,
+    layout: 'fit',
+    autoShow: true,
+    items: {
+        xtype: 'form',
+        trackResetOnLoad: true,
+        layout: 'anchor',
+        defaults: {
+            anchor: '90%',
+            margins: 10
+        },
+        url: '/rest/action.php/calendarevents/saveCalendarEvent',
+        items: [
+            {
+                xtype: 'hidden',
+                name: 'id'
+            },
+            // date_start / date_end sont recomposés par le contrôleur à partir
+            // des champs date + heure ci-dessous, pour que l'API ne reçoive
+            // qu'une date complète 'Y-m-d H:i:s'.
+            {
+                xtype: 'hidden',
+                name: 'date_start'
+            },
+            {
+                xtype: 'hidden',
+                name: 'date_end'
+            },
+            {
+                xtype: 'textfield',
+                fieldLabel: 'Saison',
+                name: 'season',
+                emptyText: '2026-2027',
+                regex: /^\d{4}-\d{4}$/,
+                regexText: 'Format attendu : 2026-2027',
+                allowBlank: false
+            },
+            {
+                xtype: 'textfield',
+                fieldLabel: 'Libellé',
+                name: 'label',
+                emptyText: 'Championnats, Férié / pont, Réunion calendrier...',
+                allowBlank: false
+            },
+            {
+                xtype: 'datefield',
+                fieldLabel: 'Date de début',
+                name: 'date_start_date',
+                submitValue: false,
+                format: 'd/m/Y',
+                allowBlank: false
+            },
+            {
+                xtype: 'timefield',
+                fieldLabel: 'Heure de début',
+                name: 'date_start_time',
+                submitValue: false,
+                format: 'H:i',
+                increment: 15,
+                // Laisser vide pour un événement sur la journée entière : la
+                // home n'affiche alors pas d'heure (cas des fériés).
+                emptyText: 'journée entière',
+                allowBlank: true
+            },
+            {
+                xtype: 'datefield',
+                fieldLabel: 'Date de fin',
+                name: 'date_end_date',
+                submitValue: false,
+                format: 'd/m/Y',
+                emptyText: 'vide = événement ponctuel',
+                allowBlank: true
+            },
+            {
+                xtype: 'timefield',
+                fieldLabel: 'Heure de fin',
+                name: 'date_end_time',
+                submitValue: false,
+                format: 'H:i',
+                increment: 15,
+                allowBlank: true
+            }
+        ],
+        buttons: [
+            {
+                text: 'Annuler',
+                action: 'cancel'
+            },
+            {
+                text: 'Sauver',
+                formBind: true,
+                disabled: true,
+                action: 'save'
+            }
+        ]
+    }
+});

--- a/pages/components/panel/Home.js
+++ b/pages/components/panel/Home.js
@@ -17,58 +17,10 @@ export default {
     `,
     data() {
         return {
-            // Événements par saison — à migrer en base de données (issue #253)
-            eventsBySeason: {
-                '2025-2026': [
-                    {date_start: '03/09/2025 19:30', date_end: null, label: 'Réunion calendrier'},
-                    {date_start: '03/09/2025 23:59', date_end: '03/10/2025 23:59', label: 'Inscriptions championnats'},
-                    {date_start: '03/09/2025 23:59', date_end: '28/11/2025 23:59', label: 'Inscriptions coupe 4x4 Khoury Hanna'},
-                    {date_start: '06/10/2025 19:30', date_end: null, label: 'Réunion début de saison'},
-                    {date_start: '09/10/2025 00:00', date_end: '13/10/2025 23:59', label: 'Tournoi(s) de bienvenue'},
-                    {date_start: '03/11/2025 00:00', date_end: '19/12/2025 23:59', label: 'Championnats'},
-                    {date_start: '20/12/2025 00:00', date_end: '04/01/2026 23:59', label: 'Vacances'},
-                    {date_start: '05/01/2026 00:00', date_end: '09/01/2026 23:59', label: 'Reports'},
-                    {date_start: '07/01/2026 19:30', date_end: null, label: 'Tirage des coupes'},
-                    {date_start: '12/01/2026 19:30', date_end: null, label: 'Réunion fin de demi-saison'},
-                    {date_start: '19/01/2026 00:00', date_end: '13/02/2026 23:59', label: 'Coupes'},
-                    {date_start: '14/02/2026 00:00', date_end: '27/02/2026 23:59', label: 'Vacances'},
-                    {date_start: '02/03/2026 00:00', date_end: '10/04/2026 23:59', label: 'Championnats'},
-                    {date_start: '11/04/2026 00:00', date_end: '26/04/2026 23:59', label: 'Vacances'},
-                    {date_start: '27/04/2026 00:00', date_end: '29/05/2026 23:59', label: 'Championnats'},
-                    {date_start: '16/06/2026 19:30', date_end: null, label: 'Réunion fin de saison'},
-                    {date_start: '01/06/2026 00:00', date_end: '19/06/2026 23:59', label: 'Phases finales Coupes'},
-                    {date_start: '26/06/2026 19:30', date_end: null, label: 'Finales + récompenses à Marignane'}
-                ],
-                '2026-2027': [
-                    {date_start: '02/09/2026 19:30', date_end: null, label: 'Réunion calendrier'},
-                    {date_start: '02/09/2026 23:59', date_end: '02/10/2026 23:59', label: 'Inscriptions championnats'},
-                    {date_start: '02/09/2026 23:59', date_end: '27/11/2026 23:59', label: 'Inscriptions coupe 4x4 Khoury Hanna'},
-                    {date_start: '05/10/2026 19:30', date_end: null, label: 'Réunion début de saison'},
-                    {date_start: '08/10/2026 00:00', date_end: '12/10/2026 23:59', label: 'Tournoi(s) de bienvenue'},
-                    {date_start: '02/11/2026 00:00', date_end: '18/12/2026 23:59', label: 'Championnats'},
-                    {date_start: '11/11/2026', date_end: null, label: 'Férié / pont'},
-                    {date_start: '19/12/2026 00:00', date_end: '03/01/2027 23:59', label: 'Vacances'},
-                    {date_start: '04/01/2027 00:00', date_end: '08/01/2027 23:59', label: 'Reports'},
-                    {date_start: '06/01/2027 19:30', date_end: null, label: 'Tirage des coupes'},
-                    {date_start: '11/01/2027 19:30', date_end: null, label: 'Réunion fin de demi-saison'},
-                    {date_start: '18/01/2027 00:00', date_end: '05/02/2027 23:59', label: 'Coupes'},
-                    {date_start: '08/02/2027 00:00', date_end: '12/02/2027 23:59', label: 'Reports'},
-                    {date_start: '20/02/2027 00:00', date_end: '07/03/2027 23:59', label: 'Vacances'},
-                    {date_start: '08/03/2027 00:00', date_end: '16/04/2027 23:59', label: 'Championnats'},
-                    {date_start: '29/03/2027', date_end: null, label: 'Férié / pont'},
-                    {date_start: '17/04/2027 00:00', date_end: '02/05/2027 23:59', label: 'Vacances'},
-                    {date_start: '03/05/2027 00:00', date_end: '14/05/2027 23:59', label: 'Coupes - 1/8 de finale'},
-                    {date_start: '17/05/2027 00:00', date_end: '21/05/2027 23:59', label: 'Coupes - 1/4 de finale'},
-                    {date_start: '24/05/2027 00:00', date_end: '28/05/2027 23:59', label: 'Coupes - 1/2 finales'},
-                    {date_start: '06/05/2027', date_end: null, label: 'Férié / pont'},
-                    {date_start: '07/05/2027', date_end: null, label: 'Férié / pont'},
-                    {date_start: '17/05/2027', date_end: null, label: 'Férié / pont'},
-                    {date_start: '31/05/2027 00:00', date_end: '04/06/2027 23:59', label: 'Championnats'},
-                    {date_start: '07/06/2027 00:00', date_end: '11/06/2027 23:59', label: 'Reports'},
-                    {date_start: '15/06/2027 19:30', date_end: null, label: 'Réunion fin de saison'},
-                    {date_start: '25/06/2027 19:30', date_end: null, label: 'Finales + récompenses'}
-                ]
-            }
+            // Alimente depuis la base (issue #253) : ces evenements etaient
+            // codes en dur ici, toute retouche demandait un deploiement.
+            importantEvents: [],
+            fetchUrl: "/rest/action.php/calendarevents/getCalendarEvents"
         };
     },
     computed: {
@@ -78,9 +30,21 @@ export default {
             // affichée est celle qui démarre en septembre de l'année en cours
             const startYear = now.getMonth() <= 5 ? now.getFullYear() - 1 : now.getFullYear();
             return `${startYear}-${startYear + 1}`;
-        },
-        importantEvents() {
-            return this.eventsBySeason[this.currentSeason] || [];
         }
+    },
+    methods: {
+        fetch() {
+            axios
+                .get(this.fetchUrl, { params: { season: this.currentSeason } })
+                .then((response) => {
+                    this.importantEvents = Array.isArray(response.data) ? response.data : [];
+                })
+                .catch((error) => {
+                    console.error("Erreur lors du chargement du calendrier:", error);
+                });
+        }
+    },
+    created() {
+        this.fetch();
     }
 };

--- a/rest/action.php
+++ b/rest/action.php
@@ -113,6 +113,10 @@ try {
             require_once __DIR__ . "/../classes/Bilan.php";
             $manager = new Bilan();
             break;
+        case 'calendarevents':
+            require_once __DIR__ . "/../classes/CalendarEvents.php";
+            $manager = new CalendarEvents();
+            break;
         case 'club':
             require_once __DIR__ . "/../classes/Club.php";
             $manager = new Club();

--- a/unit_tests/CalendarEventsTest.php
+++ b/unit_tests/CalendarEventsTest.php
@@ -1,0 +1,226 @@
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/UfolepTestCase.php';
+
+require_once __DIR__ . '/../classes/CalendarEvents.php';
+
+/**
+ * Calendrier de la home stocke en base (issue #253).
+ *
+ * Les fixtures utilisent une saison fictive '1999-2000' pour ne jamais
+ * interferer avec les saisons reelles, et sont supprimees en teardown.
+ */
+class CalendarEventsTest extends UfolepTestCase
+{
+    private const TEST_SEASON = '1999-2000';
+
+    private CalendarEvents $calendar;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->calendar = new CalendarEvents();
+        $this->purge();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->purge();
+        parent::tearDown();
+    }
+
+    private function purge(): void
+    {
+        $this->sql->execute(
+            "DELETE FROM calendar_events WHERE season = ?",
+            [['type' => 's', 'value' => self::TEST_SEASON]]
+        );
+    }
+
+    private function insertEvent(string $label, string $start, ?string $end = null): int
+    {
+        return $this->sql->execute(
+            "INSERT INTO calendar_events (season, label, date_start, date_end) VALUES (?, ?, ?, ?)",
+            [
+                ['type' => 's', 'value' => self::TEST_SEASON],
+                ['type' => 's', 'value' => $label],
+                ['type' => 's', 'value' => $start],
+                ['type' => 's', 'value' => $end],
+            ]
+        );
+    }
+
+    public function test_get_calendar_events_filters_on_season_and_sorts_by_date()
+    {
+        $this->insertEvent('Deuxieme', '1999-11-02 19:30:00');
+        $this->insertEvent('Premier', '1999-09-03 19:30:00');
+
+        $events = $this->calendar->getCalendarEvents(self::TEST_SEASON);
+
+        $this->assertCount(2, $events);
+        $this->assertEquals('Premier', $events[0]['label']);
+        $this->assertEquals('Deuxieme', $events[1]['label']);
+    }
+
+    /**
+     * Regression : les "Ferie / pont" n'avaient pas d'heure dans Home.js.
+     * Une sortie 'd/m/Y H:i' afficherait "a 00:00" sur la home.
+     */
+    public function test_all_day_point_event_is_returned_without_time()
+    {
+        $this->insertEvent('Ferie / pont', '1999-11-11 00:00:00');
+
+        $events = $this->calendar->getCalendarEvents(self::TEST_SEASON);
+
+        $this->assertEquals('11/11/1999', $events[0]['date_start']);
+        $this->assertNull($events[0]['date_end']);
+    }
+
+    public function test_point_event_with_time_keeps_its_time()
+    {
+        $this->insertEvent('Reunion calendrier', '1999-09-03 19:30:00');
+
+        $events = $this->calendar->getCalendarEvents(self::TEST_SEASON);
+
+        $this->assertEquals('03/09/1999 19:30', $events[0]['date_start']);
+        $this->assertNull($events[0]['date_end']);
+    }
+
+    public function test_period_event_returns_both_bounds()
+    {
+        $this->insertEvent('Championnats', '1999-11-03 00:00:00', '1999-12-19 23:59:00');
+
+        $events = $this->calendar->getCalendarEvents(self::TEST_SEASON);
+
+        $this->assertEquals('03/11/1999', $events[0]['date_start']);
+        $this->assertEquals('19/12/1999 23:59', $events[0]['date_end']);
+    }
+
+    public function test_get_calendar_events_defaults_to_current_season()
+    {
+        $events = $this->calendar->getCalendarEvents();
+
+        // La saison fictive ne doit jamais remonter sans filtre explicite.
+        foreach ($events as $event) {
+            $this->assertNotEquals(self::TEST_SEASON, $event['season']);
+        }
+    }
+
+    public function test_current_season_switches_in_july()
+    {
+        $season = CalendarEvents::getCurrentSeason();
+
+        // assertRegExp : PHPUnit 8, assertMatchesRegularExpression n'arrive qu'en 9.
+        $this->assertRegExp('/^\d{4}-\d{4}$/', $season);
+        [$start, $end] = explode('-', $season);
+        $this->assertEquals((int)$start + 1, (int)$end);
+
+        $expectedStart = ((int)date('n') <= 6) ? (int)date('Y') - 1 : (int)date('Y');
+        $this->assertEquals($expectedStart, (int)$start);
+    }
+
+    public function test_save_is_forbidden_for_non_admin()
+    {
+        $this->connect_as_team_leader(1);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Seuls les administrateurs peuvent modifier le calendrier");
+        $this->calendar->saveCalendarEvent(null, self::TEST_SEASON, 'Interdit', '1999-09-03 19:30:00');
+    }
+
+    public function test_save_creates_then_updates_an_event()
+    {
+        $this->connect_as_admin();
+
+        $this->calendar->saveCalendarEvent(null, self::TEST_SEASON, 'Reunion', '1999-09-03 19:30:00');
+        $events = $this->calendar->getCalendarEvents(self::TEST_SEASON);
+        $this->assertCount(1, $events);
+        $this->assertEquals('Reunion', $events[0]['label']);
+
+        $this->calendar->saveCalendarEvent(
+            $events[0]['id'],
+            self::TEST_SEASON,
+            'Reunion reportee',
+            '1999-09-10 20:00:00'
+        );
+        $events = $this->calendar->getCalendarEvents(self::TEST_SEASON);
+        $this->assertCount(1, $events);
+        $this->assertEquals('Reunion reportee', $events[0]['label']);
+        $this->assertEquals('10/09/1999 20:00', $events[0]['date_start']);
+    }
+
+    public function test_save_turns_an_empty_end_date_into_a_point_event()
+    {
+        $this->connect_as_admin();
+
+        $this->calendar->saveCalendarEvent(null, self::TEST_SEASON, 'Ponctuel', '1999-09-03 19:30:00', '');
+
+        $events = $this->calendar->getCalendarEvents(self::TEST_SEASON);
+        $this->assertNull($events[0]['date_end']);
+    }
+
+    public function test_save_rejects_an_end_before_the_start()
+    {
+        $this->connect_as_admin();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("La date de fin doit etre posterieure a la date de debut");
+        $this->calendar->saveCalendarEvent(
+            null,
+            self::TEST_SEASON,
+            'Incoherent',
+            '1999-12-19 00:00:00',
+            '1999-11-03 00:00:00'
+        );
+    }
+
+    public function test_save_rejects_missing_mandatory_fields()
+    {
+        $this->connect_as_admin();
+
+        $this->expectException(Exception::class);
+        $this->calendar->saveCalendarEvent(null, self::TEST_SEASON, '', '1999-09-03 19:30:00');
+    }
+
+    public function test_delete_is_forbidden_for_non_admin()
+    {
+        $id = $this->insertEvent('A supprimer', '1999-09-03 19:30:00');
+        $this->connect_as_team_leader(1);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Seuls les administrateurs peuvent supprimer un evenement");
+        $this->calendar->deleteCalendarEvent($id);
+    }
+
+    public function test_delete_removes_the_event()
+    {
+        $id = $this->insertEvent('A supprimer', '1999-09-03 19:30:00');
+        $this->connect_as_admin();
+
+        $this->calendar->deleteCalendarEvent($id);
+
+        $this->assertCount(0, $this->calendar->getCalendarEvents(self::TEST_SEASON));
+    }
+
+    public function test_get_all_calendar_events_exposes_iso_dates_for_the_admin_grid()
+    {
+        $this->insertEvent('Championnats', '1999-11-03 00:00:00', '1999-12-19 23:59:00');
+
+        $events = $this->calendar->getAllCalendarEvents();
+        $mine = array_values(array_filter($events, fn($e) => $e['season'] === self::TEST_SEASON));
+
+        $this->assertCount(1, $mine);
+        $this->assertEquals('1999-11-03 00:00:00', $mine[0]['date_start']);
+        $this->assertEquals('1999-12-19 23:59:00', $mine[0]['date_end']);
+    }
+
+    public function test_get_seasons_lists_the_test_season()
+    {
+        $this->insertEvent('Championnats', '1999-11-03 00:00:00');
+
+        $seasons = array_column($this->calendar->getSeasons(), 'season');
+
+        $this->assertContains(self::TEST_SEASON, $seasons);
+    }
+}

--- a/unit_tests/CalendarEventsTest.php
+++ b/unit_tests/CalendarEventsTest.php
@@ -14,6 +14,7 @@ require_once __DIR__ . '/../classes/CalendarEvents.php';
 class CalendarEventsTest extends UfolepTestCase
 {
     private const TEST_SEASON = '1999-2000';
+    private const LABEL_PREFIX = 'UT253 ';
 
     private CalendarEvents $calendar;
 
@@ -30,20 +31,28 @@ class CalendarEventsTest extends UfolepTestCase
         parent::tearDown();
     }
 
+    /**
+     * La saison fictive suffit pour l'essentiel, mais un test doit poser un
+     * evenement dans la saison courante : d'ou le nettoyage complementaire sur
+     * le prefixe de libelle.
+     */
     private function purge(): void
     {
         $this->sql->execute(
-            "DELETE FROM calendar_events WHERE season = ?",
-            [['type' => 's', 'value' => self::TEST_SEASON]]
+            "DELETE FROM calendar_events WHERE season = ? OR label LIKE ?",
+            [
+                ['type' => 's', 'value' => self::TEST_SEASON],
+                ['type' => 's', 'value' => self::LABEL_PREFIX . '%'],
+            ]
         );
     }
 
-    private function insertEvent(string $label, string $start, ?string $end = null): int
+    private function insertEvent(string $label, string $start, ?string $end = null, ?string $season = null): int
     {
         return $this->sql->execute(
             "INSERT INTO calendar_events (season, label, date_start, date_end) VALUES (?, ?, ?, ?)",
             [
-                ['type' => 's', 'value' => self::TEST_SEASON],
+                ['type' => 's', 'value' => $season ?? self::TEST_SEASON],
                 ['type' => 's', 'value' => $label],
                 ['type' => 's', 'value' => $start],
                 ['type' => 's', 'value' => $end],
@@ -99,12 +108,16 @@ class CalendarEventsTest extends UfolepTestCase
 
     public function test_get_calendar_events_defaults_to_current_season()
     {
-        $events = $this->calendar->getCalendarEvents();
+        $currentSeason = CalendarEvents::getCurrentSeason();
+        $startYear = (int)explode('-', $currentSeason)[0];
 
-        // La saison fictive ne doit jamais remonter sans filtre explicite.
-        foreach ($events as $event) {
-            $this->assertNotEquals(self::TEST_SEASON, $event['season']);
-        }
+        $this->insertEvent(self::LABEL_PREFIX . 'Saison courante', "$startYear-11-15 19:30:00", null, $currentSeason);
+        $this->insertEvent(self::LABEL_PREFIX . 'Saison fictive', '1999-11-15 19:30:00');
+
+        $labels = array_column($this->calendar->getCalendarEvents(), 'label');
+
+        $this->assertContains(self::LABEL_PREFIX . 'Saison courante', $labels);
+        $this->assertNotContains(self::LABEL_PREFIX . 'Saison fictive', $labels);
     }
 
     public function test_current_season_switches_in_july()


### PR DESCRIPTION
## Description

Résout #253

Les événements du calendrier de la home étaient codés en dur dans le tableau `eventsBySeason` de `pages/components/panel/Home.js` : toute retouche demandait un commit, un build et un déploiement. Ils vivent désormais en base et se gèrent depuis l'administration.

## Changements

**Backend**
- `classes/CalendarEvents.php` — lecture publique par saison, CRUD réservé aux admins
- route `/rest/action.php/calendarevents/`

**Front public**
- `Home.js` : appel axios sur la saison courante, plus de tableau en dur

**Administration (ExtJS)**
- `js/view/calendar_events/AdminGrid.js` + `Edit.js`, modèle, store, entrée de menu et méthodes de contrôleur

**CI**
- `.github/ci/schema.sql` régénéré via `pwsh .github/ci/dump-schema.ps1` — diff de 18 lignes, la seule table ajoutée

## Migration

À jouer séparément (repo python, `sql/updates/2026/`) : création de `calendar_events` et reprise des 45 événements existants, 18 pour 2025-2026 et 27 pour 2026-2027, dérivés automatiquement de `Home.js` plutôt que recopiés à la main. **Déjà appliquée sur la base locale.**

## Deux points de conception

**Minuit signifie « journée entière ».** Les cinq `Férié / pont` n'avaient pas d'heure dans le tableau d'origine. Les formater en `d/m/Y H:i` afficherait « à 00:00 » sur la home, ce qui serait une régression visible. L'API n'émet donc pas d'heure quand elle vaut minuit, et un test fige ce comportement.

**ExtJS classic n'a pas de champ datetime.** Le formulaire d'édition combine un `datefield` et un `timefield` dans un champ caché côté client, pour que l'API ne reçoive qu'une date complète et reste utilisable telle quelle par d'autres consommateurs.

## Tests

- [x] Tests unitaires ajoutés — `unit_tests/CalendarEventsTest.php`, 15 tests
- [x] Test E2E Playwright ajouté — `e2e/tests/issue_253.spec.js` + helpers setup/teardown
- [x] Suite complète verte en CI : **170 tests, 2662 assertions**, 0 échec
- [ ] E2E réellement exécuté — non lancé, voir ci-dessous
- [ ] UI d'administration vérifiée dans un navigateur — non lancée, voir ci-dessous

Un test a attrapé un vrai bug pendant l'écriture : l'alias `date_start` (date formatée en `jj/mm/aaaa`) masquait la colonne dans le `ORDER BY`, donc le tri se faisait sur du texte et le 02/11 passait avant le 03/09. Les colonnes du `ORDER BY` sont désormais qualifiées.

## Ce qui n'est pas vérifié

La grille d'administration ExtJS et la spec E2E n'ont pas été exécutées : les deux demandent de reconstruire l'image Docker, ce qui interrompt le serveur maison. Le câblage ExtJS a été vérifié statiquement (chemins conformes à `appFolder: 'js'`, pattern repris à l'identique de `news`), et la route REST a été testée de bout en bout avec le serveur PHP intégré — 27 événements retournés dans le bon ordre, accents préservés, férié sans heure.

## Checklist
- [x] Code review demandée
- [x] Documentation mise à jour (`CLAUDE.md` : nouveaux helpers E2E)
